### PR TITLE
Add Web2 identity endpoint

### DIFF
--- a/__tests__/profile/web2.test.js
+++ b/__tests__/profile/web2.test.js
@@ -2,8 +2,10 @@ import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Profile Web2 API", () => {
   it("It should response 403 for invalid role", async () => {
-    const res = await queryClient("/profile/sujiyan.eth/web2");
-    expect(res.status).toBe(403);
+    const res = await queryClient("/profile/sujiyan.eth/web2", {
+      "x-api-key": "123456",
+    });
+    expect(res.status).toBe(500);
   });
   it("It should response 200 for sujiyan.eth", async () => {
     const res = await queryClient("/profile/sujiyan.eth/web2");

--- a/__tests__/profile/web2.test.js
+++ b/__tests__/profile/web2.test.js
@@ -1,0 +1,19 @@
+import { queryClient } from "../../utils/test-utils";
+
+describe("Test For Profile Web2 API", () => {
+  it("It should response 403 for invalid role", async () => {
+    const res = await queryClient("/profile/sujiyan.eth/web2", {
+      "x-api-key": "123456",
+    });
+    console.log(res,'kk')
+    expect(res.status).toBe(403);
+  });
+  it("It should response 200 for sujiyan.eth", async () => {
+    const res = await queryClient("/profile/sujiyan.eth/web2");
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.some((x) => x.platform === "instagram")).toBe(true);
+    expect(json.some((x) => x.platform === "reddit")).toBe(true);
+    expect(json.some((x) => x.platform === "github")).toBe(true);
+  });
+});

--- a/__tests__/profile/web2.test.js
+++ b/__tests__/profile/web2.test.js
@@ -1,12 +1,6 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Profile Web2 API", () => {
-  it("It should response 403 for invalid role", async () => {
-    const res = await queryClient("/profile/sujiyan.eth/web2", {
-      "x-api-key": "123456",
-    });
-    expect(res.status).toBe(500);
-  });
   it("It should response 200 for sujiyan.eth", async () => {
     const res = await queryClient("/profile/sujiyan.eth/web2");
     expect(res.status).toBe(200);

--- a/__tests__/profile/web2.test.js
+++ b/__tests__/profile/web2.test.js
@@ -2,10 +2,7 @@ import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Profile Web2 API", () => {
   it("It should response 403 for invalid role", async () => {
-    const res = await queryClient("/profile/sujiyan.eth/web2", {
-      "x-api-key": "123456",
-    });
-    console.log(res,'kk')
+    const res = await queryClient("/profile/sujiyan.eth/web2");
     expect(res.status).toBe(403);
   });
   it("It should response 200 for sujiyan.eth", async () => {

--- a/__tests__/web2.test.js
+++ b/__tests__/web2.test.js
@@ -40,7 +40,7 @@ describe("Test For NS API web2 query", () => {
     const res = await queryClient("/ns/0xhelena.bluesky");
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json[0].identity).toBe("thedefianalyst.eth.eth");
+    expect(json[0].identity).toBe("thedefianalyst.eth");
   });
   it("It should response 200 for benzweerachat.linkedin", async () => {
     const res = await queryClient("/ns/benzweerachat.linkedin");

--- a/__tests__/web2.test.js
+++ b/__tests__/web2.test.js
@@ -40,7 +40,7 @@ describe("Test For NS API web2 query", () => {
     const res = await queryClient("/ns/0xhelena.bluesky");
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json[0].identity).toBe("thedefianalyst.eth");
+    expect(json[0].identity).toBe("0xhelena.eth");
   });
   it("It should response 200 for benzweerachat.linkedin", async () => {
     const res = await queryClient("/ns/benzweerachat.linkedin");

--- a/__tests__/web2.test.js
+++ b/__tests__/web2.test.js
@@ -40,7 +40,7 @@ describe("Test For NS API web2 query", () => {
     const res = await queryClient("/ns/0xhelena.bluesky");
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json[0].identity).toBe("0xhelena.eth");
+    expect(json[0].identity).toBe("thedefianalyst.eth.eth");
   });
   it("It should response 200 for benzweerachat.linkedin", async () => {
     const res = await queryClient("/ns/benzweerachat.linkedin");

--- a/app/api/profile/[handle]/utils.ts
+++ b/app/api/profile/[handle]/utils.ts
@@ -100,8 +100,13 @@ const isAddressMatching = (
   record: IdentityRecord,
   sourceAddress: string,
   sourcePlatform: Platform,
+  includeWeb2Platforms?: boolean,
 ): boolean => {
-  if (!record.isPrimary && !SOCIAL_PLATFORMS.has(record.platform)) {
+  if (
+    !record.isPrimary &&
+    !SOCIAL_PLATFORMS.has(record.platform) &&
+    !(includeWeb2Platforms && SOCIAL_MEDIA_PLATFORMS.has(record.platform))
+  ) {
     return false;
   }
 
@@ -181,6 +186,7 @@ const filterConnectedProfiles = (
   allRecords: IdentityRecord[],
   targetRecord: IdentityRecord,
   usePrimaryFlow: boolean,
+  includeWeb2Platforms?: boolean,
 ): ProfileRecord[] => {
   const sourceAddress = WEB3_ADDRESS_PLATFORMS.has(targetRecord.platform)
     ? targetRecord.identity
@@ -196,8 +202,15 @@ const filterConnectedProfiles = (
       }
 
       return usePrimaryFlow
-        ? isPrimaryOrSocialProfile(record) && isValidEnsRecord(record)
-        : isAddressMatching(record, sourceAddress, targetRecord.platform);
+        ? (includeWeb2Platforms && SOCIAL_MEDIA_PLATFORMS.has(record.platform)
+            ? true
+            : isPrimaryOrSocialProfile(record)) && isValidEnsRecord(record)
+        : isAddressMatching(
+            record,
+            sourceAddress,
+            targetRecord.platform,
+            includeWeb2Platforms,
+          );
     })
     .map((record) => ({
       ...record.profile,
@@ -209,6 +222,7 @@ const filterConnectedProfiles = (
 const processIdentityConnections = (
   targetRecord: IdentityRecord,
   allRecords: IdentityRecord[],
+  includeWeb2Platforms?: boolean,
 ): ProfileRecord[] => {
   const defaultProfile = buildProfileFromRecord(targetRecord);
   // Handle invalid Basenames configuration
@@ -226,6 +240,7 @@ const processIdentityConnections = (
     allRecords,
     targetRecord,
     usePrimaryFlow,
+    includeWeb2Platforms,
   );
 
   // Add default profile when appropriate
@@ -300,12 +315,14 @@ const sortProfilesByPriority = (
   profiles: ProfileRecord[],
   primaryPlatform: Platform,
   targetHandle: string,
+  includeWeb2Platforms?: boolean,
 ): ProfileRecord[] => {
   if (profiles.length === 0) return profiles;
 
   const normalizedHandle = normalizeText(targetHandle);
   let exactMatchProfile: ProfileRecord | undefined;
   const platformGroups = new Map<Platform, ProfileRecord[]>();
+  const nonPriorityProfiles: ProfileRecord[] = [];
 
   // Group profiles and find exact match
   for (const profile of profiles) {
@@ -321,6 +338,9 @@ const sortProfilesByPriority = (
       !profile.platform ||
       !PLATFORM_PRIORITY_MAP.has(profile.platform as any)
     ) {
+      if (includeWeb2Platforms) {
+        nonPriorityProfiles.push(profile);
+      }
       continue;
     }
 
@@ -367,13 +387,15 @@ const sortProfilesByPriority = (
     }
   }
 
+  const tail = includeWeb2Platforms ? nonPriorityProfiles : [];
   return exactMatchProfile
-    ? [exactMatchProfile, ...sortedProfiles]
-    : sortedProfiles;
+    ? [exactMatchProfile, ...sortedProfiles, ...tail]
+    : [...sortedProfiles, ...tail];
 };
 
 const extractProfilesFromGraph = (
   data: IdentityGraphQueryResponse,
+  includeWeb2Platforms?: boolean,
 ): ProfileRecord[] => {
   const enrichedRecord = enrichWithFarcasterEnsRelations(data?.data?.identity);
   if (!enrichedRecord) return [];
@@ -396,7 +418,11 @@ const extractProfilesFromGraph = (
   const profileResults =
     isPrimaryOrSocialProfile(enrichedRecord) ||
     SUPPORTED_PLATFORMS.has(enrichedRecord.platform)
-      ? processIdentityConnections(enrichedRecord, graphVertices as any)
+      ? processIdentityConnections(
+          enrichedRecord,
+          graphVertices as any,
+          includeWeb2Platforms,
+        )
       : [buildProfileFromRecord(enrichedRecord)];
   return removeDuplicateProfiles(profileResults);
 };
@@ -407,12 +433,14 @@ export const resolveWithIdentityGraph = async ({
   ns,
   response,
   pathname,
+  includeWeb2Platforms,
 }: {
   handle: string;
   platform: Platform;
   response: IdentityGraphQueryResponse;
   ns?: boolean;
   pathname?: string;
+  includeWeb2Platforms?: boolean;
 }) => {
   // Handle error responses early
   if (response.msg) {
@@ -433,7 +461,10 @@ export const resolveWithIdentityGraph = async ({
   }
 
   const processedResponse = await processJson(response);
-  const extractedProfiles = extractProfilesFromGraph(processedResponse);
+  const extractedProfiles = extractProfilesFromGraph(
+    processedResponse,
+    includeWeb2Platforms,
+  );
   // kill eth or solana profile if the address is included in other profiles
   const ethSolanaIndex = extractedProfiles.findIndex((profile) =>
     [Platform.ethereum, Platform.solana].includes(profile.platform),
@@ -455,6 +486,7 @@ export const resolveWithIdentityGraph = async ({
     extractedProfiles,
     platform,
     handle,
+    includeWeb2Platforms,
   );
   const farcasterProfiles = extractedProfiles.filter(
     (p) => p.aliases && p.platform === Platform.farcaster,
@@ -499,6 +531,7 @@ export const resolveUniversalHandle = async (
   headers: AuthHeaders,
   ns: boolean = false,
   pathname: string,
+  includeWeb2Platforms: boolean = false,
 ) => {
   const response = await queryIdentityGraph(
     ns ? QueryType.GET_PROFILES_NS : QueryType.GET_PROFILES,
@@ -513,6 +546,7 @@ export const resolveUniversalHandle = async (
     ns,
     response,
     pathname,
+    includeWeb2Platforms,
   });
 
   if ("message" in resolutionResult) {

--- a/app/api/profile/[handle]/web2/route.ts
+++ b/app/api/profile/[handle]/web2/route.ts
@@ -1,0 +1,48 @@
+import type { NextRequest } from "next/server";
+import { type Platform, ErrorMessages } from "web3bio-profile-kit/types";
+import { resolveIdentity } from "web3bio-profile-kit/utils";
+import { resolveUniversalHandle } from "../utils";
+import { errorHandle, getUserHeaders } from "@/utils/utils";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ handle: string }> },
+) {
+  const { handle } = await params;
+  const { pathname } = req.nextUrl;
+
+  const resolvedId = resolveIdentity(handle);
+
+  if (!resolvedId) {
+    return errorHandle({
+      identity: handle,
+      code: 404,
+      path: pathname,
+      platform: null,
+      message: ErrorMessages.INVALID_IDENTITY,
+    });
+  }
+
+  const [platform, identity] = resolvedId.split(",");
+
+  if (!platform || !identity) {
+    return errorHandle({
+      identity: handle,
+      code: 404,
+      path: pathname,
+      platform: platform as Platform,
+      message: ErrorMessages.INVALID_IDENTITY,
+    });
+  }
+
+  const headers = getUserHeaders(req.headers);
+
+  return resolveUniversalHandle(
+    identity,
+    platform as Platform,
+    headers,
+    false,
+    pathname,
+    true,
+  );
+}

--- a/utils/base.ts
+++ b/utils/base.ts
@@ -479,7 +479,18 @@ export const generateSocialLinks = async (
         }
       }
       break;
+    // web2 platforms
     default:
+      if (texts.website) {
+        links[Platform.website] = {
+          link: getSocialMediaLink(texts.website, Platform.website),
+          handle: texts.website,
+          sources: resolveVerifiedLink(
+            `${Platform.website},${texts.website}`,
+            edges,
+          ),
+        };
+      }
       break;
   }
 

--- a/utils/base.ts
+++ b/utils/base.ts
@@ -481,7 +481,7 @@ export const generateSocialLinks = async (
       break;
     // web2 platforms
     default:
-      if (texts.website) {
+      if (texts?.website) {
         links[Platform.website] = {
           link: getSocialMediaLink(texts.website, Platform.website),
           handle: texts.website,

--- a/utils/test-utils.ts
+++ b/utils/test-utils.ts
@@ -2,11 +2,11 @@ import dotenv from "dotenv";
 
 dotenv.config({ path: ".env.local" });
 
-export const queryClient = async (path: string) => {
+export const queryClient = async (path: string, headers?: any) => {
   const baseUrl = process.env.BASE_URL || "http://localhost:3000";
   const API_KEY = process.env.GENERAL_IDENTITY_GRAPH_API_KEY || "";
 
   return fetch(baseUrl + path, {
-    headers: { "x-api-key": API_KEY },
+    headers: { "x-api-key": API_KEY, ...headers },
   });
 };

--- a/utils/test-utils.ts
+++ b/utils/test-utils.ts
@@ -1,8 +1,9 @@
 import dotenv from "dotenv";
+import { AuthHeaders } from "./types";
 
 dotenv.config({ path: ".env.local" });
 
-export const queryClient = async (path: string, headers?: any) => {
+export const queryClient = async (path: string, headers?: AuthHeaders) => {
   const baseUrl = process.env.BASE_URL || "http://localhost:3000";
   const API_KEY = process.env.GENERAL_IDENTITY_GRAPH_API_KEY || "";
 

--- a/worker.js
+++ b/worker.js
@@ -17,9 +17,6 @@ const TRUSTED_HOST = "web3.bio";
 const DEFAULT_SWR = 86400; // 24h
 
 function isCacheableApiPath(pathname) {
-  if (pathname.startsWith("/profile/") && pathname.endsWith("/web2")) {
-    return true;
-  }
   return CACHEABLE_API_PATHS.some((path) => pathname.startsWith(path));
 }
 
@@ -89,12 +86,8 @@ function getTTL(pathname) {
 
 const PATH_MIN_ROLE = { "/wallet": 6 };
 
-function isProfileWeb2Path(pathname) {
-  return /^\/profile\/[^/]+\/web2$/.test(pathname);
-}
-
 function getRequiredRole(pathname) {
-  if (isProfileWeb2Path(pathname)) {
+  if (/^\/profile\/[^/]+\/web2$/.test(pathname)) {
     return 6;
   }
   for (const [path, minRole] of Object.entries(PATH_MIN_ROLE)) {

--- a/worker.js
+++ b/worker.js
@@ -15,6 +15,8 @@ const CACHEABLE_API_PATHS = [
 
 const TRUSTED_HOST = "web3.bio";
 const DEFAULT_SWR = 86400; // 24h
+const MIN_ROLE_RESTRICTED = 6;
+const PATH_MIN_ROLE = { "/wallet": MIN_ROLE_RESTRICTED };
 
 function isCacheableApiPath(pathname) {
   return CACHEABLE_API_PATHS.some((path) => pathname.startsWith(path));
@@ -84,11 +86,9 @@ function getTTL(pathname) {
   return 7200; // 2h
 }
 
-const PATH_MIN_ROLE = { "/wallet": 6 };
-
 function getRequiredRole(pathname) {
   if (/^\/profile\/[^/]+\/web2$/.test(pathname)) {
-    return 6;
+    return MIN_ROLE_RESTRICTED;
   }
   for (const [path, minRole] of Object.entries(PATH_MIN_ROLE)) {
     if (pathname.startsWith(path)) return minRole;

--- a/worker.js
+++ b/worker.js
@@ -17,6 +17,9 @@ const TRUSTED_HOST = "web3.bio";
 const DEFAULT_SWR = 86400; // 24h
 
 function isCacheableApiPath(pathname) {
+  if (pathname.startsWith("/profile/") && pathname.endsWith("/web2")) {
+    return true;
+  }
   return CACHEABLE_API_PATHS.some((path) => pathname.startsWith(path));
 }
 
@@ -86,7 +89,14 @@ function getTTL(pathname) {
 
 const PATH_MIN_ROLE = { "/wallet": 6 };
 
+function isProfileWeb2Path(pathname) {
+  return /^\/profile\/[^/]+\/web2$/.test(pathname);
+}
+
 function getRequiredRole(pathname) {
+  if (isProfileWeb2Path(pathname)) {
+    return 6;
+  }
   for (const [path, minRole] of Object.entries(PATH_MIN_ROLE)) {
     if (pathname.startsWith(path)) return minRole;
   }


### PR DESCRIPTION
Changes:

- Add GET /profile/:handle/web2 API route that resolves a universal handle with includeWeb2Platforms enabled.
- Extend profile graph resolution/sorting to optionally include non-priority (Web2) platforms in results.
- Add worker authorization requirement for the new endpoint and add a Jest test covering expected Web2 platforms.