### PR TITLE
Staging

### DIFF
--- a/__tests__/avatar.test.js
+++ b/__tests__/avatar.test.js
@@ -1,26 +1,26 @@
 import { queryClient } from "../utils/test-utils";
 
 describe("Test For Avatar Service API", () => {
-  it("It should response 200 for vitalik.eth", async () => {
+  it("It should respond 200 for vitalik.eth", async () => {
     const res = await queryClient("/avatar/vitalik.eth");
     expect(res.status).toBe(200);
     const text = await res.text();
     expect(text.startsWith("https"));
   });
-  it("It should response 200 for bonfida.sol", async () => {
+  it("It should respond 200 for bonfida.sol", async () => {
     const res = await queryClient("/avatar/bonfida.sol");
     expect(res.status).toBe(200);
     const text = await res.text();
     expect(text.startsWith("<svg"));
   });
-  it("It should response 200 for xxxxx.xxxxx", async () => {
+  it("It should respond 200 for xxxxx.xxxxx", async () => {
     const res = await queryClient("/avatar/xxxxx.xxxxx");
     expect(res.status).toBe(200);
     const text = await res.text();
     expect(text.startsWith("<svg"));
   });
 
-  it("It should response 200 for suji.eth", async () => {
+  it("It should respond 200 for suji.eth", async () => {
     const res = await queryClient("/avatar/suji.eth");
     expect(res.status).toBe(200);
     const text = await res.text();

--- a/__tests__/credential.test.js
+++ b/__tests__/credential.test.js
@@ -1,7 +1,7 @@
 import { queryClient } from "../utils/test-utils";
 
 describe("Test For Credential API", () => {
-  it("It should response 200 for ggmonster.farcaster", async () => {
+  it("It should respond 200 for ggmonster.farcaster", async () => {
     const res = await queryClient("/credential/ggmonster.farcaster");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -10,7 +10,7 @@ describe("Test For Credential API", () => {
     expect(json.isRisky[0].credentialSource).toBe("dmca");
     expect(json.isSpam[0].link).toBe("https://github.com/warpcast/labels");
   });
-  it("It should response 200 for 0xb6a5426b885172fb73d3c8fcf9612610612df707", async () => {
+  it("It should respond 200 for 0xb6a5426b885172fb73d3c8fcf9612610612df707", async () => {
     const res = await queryClient(
       "/credential/0xb6a5426b885172fb73d3c8fcf9612610612df707",
     );
@@ -22,7 +22,7 @@ describe("Test For Credential API", () => {
     expect(json.isRisky[0].value).toBe("true");
     expect(json.isRisky[0].credentialSource).toBe("hacker");
   });
-  it("It should response 200 for supahmars.eth", async () => {
+  it("It should respond 200 for supahmars.eth", async () => {
     const res = await queryClient("/credential/supahmars.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -30,13 +30,13 @@ describe("Test For Credential API", () => {
     expect(json.isHuman[0].credentialSource).toBe("dentity");
     expect(json.isHuman[0].platform).toBe("dentity");
   });
-  it("It should response 200 for 0xhelena.eth", async () => {
+  it("It should respond 200 for 0xhelena.eth", async () => {
     const res = await queryClient("/credential/0xhelena.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.isHuman[0].value).toBe("true");
   });
-  it("It should response 200 for 0x54503eeded1fc55b94330bf82092ad41a76a8683", async () => {
+  it("It should respond 200 for 0x54503eeded1fc55b94330bf82092ad41a76a8683", async () => {
     const res = await queryClient(
       "/credential/0x54503eeded1fc55b94330bf82092ad41a76a8683",
     );

--- a/__tests__/domain.test.js
+++ b/__tests__/domain.test.js
@@ -1,13 +1,13 @@
 import { queryClient } from "../utils/test-utils";
 
 describe("Test For Domain API", () => {
-  it("It should response 200 for ens,sujiyan.eth", async () => {
+  it("It should respond 200 for ens,sujiyan.eth", async () => {
     const res = await queryClient("/domain/ens,sujiyan.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.identity).toBe("sujiyan.eth");
   });
-  it("It should response 200 for bonfida.sol", async () => {
+  it("It should respond 200 for bonfida.sol", async () => {
     const res = await queryClient("/domain/bonfida.sol");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -15,23 +15,23 @@ describe("Test For Domain API", () => {
       "Fw1ETanDZafof7xEULsnq9UY6o71Tpds89tNwPkWLb1v",
     );
   });
-  it("It should response 200 for dwr.farcaster", async () => {
+  it("It should respond 200 for dwr.farcaster", async () => {
     const res = await queryClient("/domain/dwr.farcaster");
     expect(res.status).toBe(404);
   });
-  it("It should response 200 for linea,184.linea.eth", async () => {
+  it("It should respond 200 for linea,184.linea.eth", async () => {
     const res = await queryClient("/domain/linea,184.linea.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.addresses.dogecoin).toBe("D8ehuDjCuZkWLGQoaqbghFd9fJ4a72PKTh");
   });
-  it("It should response 200 for linea,184.linea.eth", async () => {
+  it("It should respond 200 for linea,184.linea.eth", async () => {
     const res = await queryClient("/domain/linea,184.linea.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.addresses.dogecoin).toBe("D8ehuDjCuZkWLGQoaqbghFd9fJ4a72PKTh");
   });
-  it("It should response 200 for 0xc28de09ad1a20737b92834943558ddfcc88d020d", async () => {
+  it("It should respond 200 for 0xc28de09ad1a20737b92834943558ddfcc88d020d", async () => {
     const res = await queryClient(
       "/domain/0xc28de09ad1a20737b92834943558ddfcc88d020d",
     );

--- a/__tests__/ns/basenames.test.js
+++ b/__tests__/ns/basenames.test.js
@@ -1,13 +1,13 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For BaseNames NS API", () => {
-  it("It should response 200 for jesse.base.eth", async () => {
+  it("It should respond 200 for jesse.base.eth", async () => {
     const res = await queryClient("/ns/basenames/jesse.base.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBe("0x2211d1d0020daea8039e46cf1367962070d77da9");
   });
-  it("It should response 200 for 0xce40d3c0041e7720ad2bc7a841ff05cc7923532d", async () => {
+  it("It should respond 200 for 0xce40d3c0041e7720ad2bc7a841ff05cc7923532d", async () => {
     const res = await queryClient(
       "/ns/basenames/0xce40d3c0041e7720ad2bc7a841ff05cc7923532d",
     );
@@ -15,7 +15,7 @@ describe("Test For BaseNames NS API", () => {
     const json = await res.json();
     expect(json.identity).toBe("fitz.base.eth");
   });
-  it("It should response 200 for drishka.base", async () => {
+  it("It should respond 200 for drishka.base", async () => {
     const res = await queryClient("/ns/basenames/drishka.base");
     expect(res.status).toBe(200);
     const json = await res.json();

--- a/__tests__/ns/batch.test.js
+++ b/__tests__/ns/batch.test.js
@@ -8,7 +8,7 @@ describe("Test For Batch Query", () => {
     "farcaster,dwr.eth",
   ];
 
-  it("It should response 200 for Batch Query GET", async () => {
+  it("It should respond 200 for Batch Query GET", async () => {
     const url = `/ns/batch/${encodeURIComponent(JSON.stringify(getIds))}`;
     const res = await queryClient(url);
     expect(res.status).toBe(200);

--- a/__tests__/ns/ens.test.js
+++ b/__tests__/ns/ens.test.js
@@ -1,7 +1,7 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For ENS NS API", () => {
-  it("It should response 200 for brantly.eth", async () => {
+  it("It should respond 200 for brantly.eth", async () => {
     const res = await queryClient("/ns/ens/brantly.eth");
     const json = await res.json();
     expect(res.status).toBe(200);
@@ -9,31 +9,31 @@ describe("Test For ENS NS API", () => {
     expect(json).toHaveProperty("status");
     expect(json).toHaveProperty("header");
   });
-  it("It should response 404 for mcdonalds.eth", async () => {
+  it("It should respond 404 for mcdonalds.eth", async () => {
     const res = await queryClient("/ns/ens/mcdonalds.eth");
     expect(res.status).toBe(200);
   });
 
-  it("It should response 200 for sujiyan.eth", async () => {
+  it("It should respond 200 for sujiyan.eth", async () => {
     const res = await queryClient("/ns/ens/sujiyan.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.platform).toBe("ens");
   });
-  it("It should response 200 for vitalik.eth", async () => {
+  it("It should respond 200 for vitalik.eth", async () => {
     const res = await queryClient("/ns/ens/vitalik.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.platform).toBe("ens");
   });
 
-  it("It should response 200 for 0xhelena.eth", async () => {
+  it("It should respond 200 for 0xhelena.eth", async () => {
     const res = await queryClient("/ns/ens/0xhelena.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.avatar).toBeTruthy();
   });
-  it("It should response 200 for 0xc0074d4f69f4281d7a8eb4d266348ba9f7599e0a", async () => {
+  it("It should respond 200 for 0xc0074d4f69f4281d7a8eb4d266348ba9f7599e0a", async () => {
     const res = await queryClient(
       "/ns/ens/0xc0074d4f69f4281d7a8eb4d266348ba9f7599e0a",
     );

--- a/__tests__/ns/ethereum.test.js
+++ b/__tests__/ns/ethereum.test.js
@@ -1,24 +1,24 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Ethereum Profile API", () => {
-  it("It should response 200 for sio.eth", async () => {
+  it("It should respond 200 for sio.eth", async () => {
     const res = await queryClient("/ns/ethereum/luc.eth");
     const json = await res.json();
     expect(json.identity).toBeTruthy();
   });
-  it("It should response 200 for planetable.eth", async () => {
+  it("It should respond 200 for planetable.eth", async () => {
     const res = await queryClient("/ns/ethereum/planetable.eth");
     const json = await res.json();
     expect(json.address).toBe("0x18deee9699526f8c8a87004b2e4e55029fb26b9a");
     expect(json.platform).toBe("ens");
   });
-  it("It should response 200 for 0x7241DDDec3A6aF367882eAF9651b87E1C7549Dff", async () => {
+  it("It should respond 200 for 0x7241DDDec3A6aF367882eAF9651b87E1C7549Dff", async () => {
     const res = await queryClient(
-      "/ns/ethereum/0x7241DDDec3A6aF367882eAF9651b87E1C7549Dff"
+      "/ns/ethereum/0x7241DDDec3A6aF367882eAF9651b87E1C7549Dff",
     );
     const json = await res.json();
     const res2 = await queryClient(
-      "/ns/ens/0x7241DDDec3A6aF367882eAF9651b87E1C7549Dff"
+      "/ns/ens/0x7241DDDec3A6aF367882eAF9651b87E1C7549Dff",
     );
     const json2 = await res2.json();
     expect(json.displayName).toBe(json2.displayName);

--- a/__tests__/ns/farcaster.test.js
+++ b/__tests__/ns/farcaster.test.js
@@ -1,13 +1,13 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Farcaster NS API", () => {
-  it("It should response 200 for suji", async () => {
+  it("It should respond 200 for suji", async () => {
     const res = await queryClient("/ns/farcaster/suji");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.identity).toBe("suji");
   });
-  it("It should response 200 for 0x7cbba07e31dc7b12bb69a1209c5b11a8ac50acf5", async () => {
+  it("It should respond 200 for 0x7cbba07e31dc7b12bb69a1209c5b11a8ac50acf5", async () => {
     const res = await queryClient(
       "/ns/farcaster/0x7cbba07e31dc7b12bb69a1209c5b11a8ac50acf5",
     );
@@ -17,14 +17,14 @@ describe("Test For Farcaster NS API", () => {
     expect(json.address).toBeTruthy();
   });
 
-  it("It should response 404 for dwr", async () => {
+  it("It should respond 404 for dwr", async () => {
     const res = await queryClient("/ns/farcaster/dwr");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.displayName).toBe("Dan Romero");
     expect(json.address).toBeTruthy();
   });
-  it("It should response 200 for dwr.eth", async () => {
+  it("It should respond 200 for dwr.eth", async () => {
     const res = await queryClient("/ns/farcaster/dwr.eth");
     expect(res.status).toBe(200);
     const json = await res.json();

--- a/__tests__/ns/lens.test.js
+++ b/__tests__/ns/lens.test.js
@@ -1,13 +1,13 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Lens NS API", () => {
-  it("It should response 200 for sujiyan.lens", async () => {
+  it("It should respond 200 for sujiyan.lens", async () => {
     const res = await queryClient("/ns/lens/sujiyan.lens");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBe("0x9a96f14e39fe946014ff1a11540c4d4f7b441006");
   });
-  it("It should response 200 for stani.lens", async () => {
+  it("It should respond 200 for stani.lens", async () => {
     const res = await queryClient("/ns/lens/stani.lens");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -15,18 +15,18 @@ describe("Test For Lens NS API", () => {
     expect(json.address).toBe("0x7241dddec3a6af367882eaf9651b87e1c7549dff");
   });
 
-  it("It should response 404 for 0xxxxxxxxxx", async () => {
+  it("It should respond 404 for 0xxxxxxxxxx", async () => {
     const res = await queryClient("/ns/lens/0xxxxxxxxxx");
     expect(res.status).toBe(404);
     expect((await res.json()).error).toBe("Invalid Identity or Domain");
   });
 
-  it("It should response 404 for sujiyan.eth", async () => {
+  it("It should respond 404 for sujiyan.eth", async () => {
     const res = await queryClient("/ns/lens/sujiyan.eth");
     expect(res.status).toBe(404);
     expect((await res.json()).error).toBe("Invalid Identity or Domain");
   });
-  it("It should response 200 for sujidaily.lens", async () => {
+  it("It should respond 200 for sujidaily.lens", async () => {
     const res = await queryClient("/ns/lens/sujidaily.lens");
     expect(res.status).toBe(200);
     expect((await res.json()).avatar).toBeTruthy();

--- a/__tests__/ns/linea.test.js
+++ b/__tests__/ns/linea.test.js
@@ -1,15 +1,15 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Linea NS API", () => {
-  it("It should response 200 for suji.linea.eth", async () => {
+  it("It should respond 200 for suji.linea.eth", async () => {
     const res = await queryClient("/ns/linea/suji");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBe("0x15fecfa8fa295ad7383d84d172dbe51792fa95bb");
   });
-  it("It should response 200 for 0xc28de09ad1a20737b92834943558ddfcc88d020d", async () => {
+  it("It should respond 200 for 0xc28de09ad1a20737b92834943558ddfcc88d020d", async () => {
     const res = await queryClient(
-      "/ns/linea/0xc28de09ad1a20737b92834943558ddfcc88d020d"
+      "/ns/linea/0xc28de09ad1a20737b92834943558ddfcc88d020d",
     );
     expect(res.status).toBe(200);
     const json = await res.json();

--- a/__tests__/ns/sns.test.js
+++ b/__tests__/ns/sns.test.js
@@ -1,31 +1,31 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For SNS NS API", () => {
-  it("It should response 200 for bonfida.sol", async () => {
+  it("It should respond 200 for bonfida.sol", async () => {
     const res = await queryClient("/ns/sns/bonfida.sol");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBe("Fw1ETanDZafof7xEULsnq9UY6o71Tpds89tNwPkWLb1v");
   });
-  it("It should response 200 for sujiyan.sol", async () => {
+  it("It should respond 200 for sujiyan.sol", async () => {
     const res = await queryClient("/ns/sns/sujiyan.sol");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBe("2E3k7otC558kJJsK8wV8oehXf2VxPRQA3LtyW2mvF6w5");
   });
-  it("It should response 200 for _tesla.sol", async () => {
+  it("It should respond 200 for _tesla.sol", async () => {
     const res = await queryClient("/ns/sns/_tesla.sol");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBeTruthy();
   });
-  it("It should response 200 for wallet-guide-9.sol", async () => {
+  it("It should respond 200 for wallet-guide-9.sol", async () => {
     const res = await queryClient("/ns/sns/wallet-guide-9.sol");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.avatar).toBeTruthy();
   });
-  it("It should response 200 for 9mUxj781h7UXDFcbesr1YUfVGD2kQZgsUMc5kzpL9g65", async () => {
+  it("It should respond 200 for 9mUxj781h7UXDFcbesr1YUfVGD2kQZgsUMc5kzpL9g65", async () => {
     const res = await queryClient(
       "/ns/sns/9mUxj781h7UXDFcbesr1YUfVGD2kQZgsUMc5kzpL9g65",
     );

--- a/__tests__/ns/solana.test.js
+++ b/__tests__/ns/solana.test.js
@@ -1,14 +1,14 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Solana NS API", () => {
-  it("It should response 200 for bonfida.sol", async () => {
+  it("It should respond 200 for bonfida.sol", async () => {
     const res = await queryClient("/ns/solana/bonfida.sol");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBe("Fw1ETanDZafof7xEULsnq9UY6o71Tpds89tNwPkWLb1v");
     expect(json.platform).toBe("sns");
   });
-  it("It should response 200 for 2E3k7otC558kJJsK8wV8oehXf2VxPRQA3LtyW2mvF6w5", async () => {
+  it("It should respond 200 for 2E3k7otC558kJJsK8wV8oehXf2VxPRQA3LtyW2mvF6w5", async () => {
     const res = await queryClient(
       "/ns/solana/2E3k7otC558kJJsK8wV8oehXf2VxPRQA3LtyW2mvF6w5",
     );

--- a/__tests__/ns/ud.test.js
+++ b/__tests__/ns/ud.test.js
@@ -1,11 +1,11 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Unstoppable Domains NS API", () => {
-  it("It should response 200 for sandy.x", async () => {
+  it("It should respond 200 for sandy.x", async () => {
     const res = await queryClient("/ns/unstoppabledomains/sandy.x");
     expect(res.status).toBe(200);
   });
-  it("It should response 200 for al.x", async () => {
+  it("It should respond 200 for al.x", async () => {
     const res = await queryClient("/ns/unstoppabledomains/al.x");
     expect(res.status).toBe(200);
     const json = await res.json();

--- a/__tests__/ns/universal.test.js
+++ b/__tests__/ns/universal.test.js
@@ -1,7 +1,7 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Universal NS API", () => {
-  it("It should response 200 for sujiyan.lens", async () => {
+  it("It should respond 200 for sujiyan.lens", async () => {
     const res = await queryClient("/ns/sujiyan.lens");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -11,26 +11,26 @@ describe("Test For Universal NS API", () => {
     );
   });
 
-  it("It should response 200 data for stani.lens", async () => {
+  it("It should respond 200 data for stani.lens", async () => {
     const res = await queryClient("/ns/stani.lens");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json[0].identity).toBe("stani.lens");
   });
 
-  it("It should response 200 data for gamedb.eth", async () => {
+  it("It should respond 200 data for gamedb.eth", async () => {
     const res = await queryClient("/profile/gamedb.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.find((x) => x.platform === "ens").identity).toBe("gamedb.eth");
   });
-  it("It should response 200 data for livid.farcaster", async () => {
+  it("It should respond 200 data for livid.farcaster", async () => {
     const res = await queryClient("/ns/livid.farcaster");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.find((x) => x.platform === "farcaster").identity).toBe("livid");
   });
-  it("It should response 200 data for luc.eth", async () => {
+  it("It should respond 200 data for luc.eth", async () => {
     const res = await queryClient("/ns/luc.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -41,7 +41,7 @@ describe("Test For Universal NS API", () => {
       ).length,
     ).toBe(0);
   });
-  it("It should response 200 data for 184.linea.eth", async () => {
+  it("It should respond 200 data for 184.linea.eth", async () => {
     const res = await queryClient("/ns/184.linea");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -49,7 +49,7 @@ describe("Test For Universal NS API", () => {
     expect(json[0].identity).toBe("184.linea.eth");
     expect(json[1].platform).toBe("ens");
   });
-  it("It should response 200 data for 0xc28de09ad1a20737b92834943558ddfcc88d020d", async () => {
+  it("It should respond 200 data for 0xc28de09ad1a20737b92834943558ddfcc88d020d", async () => {
     const res = await queryClient(
       "/ns/0xc28de09ad1a20737b92834943558ddfcc88d020d",
     );
@@ -57,13 +57,13 @@ describe("Test For Universal NS API", () => {
     const json = await res.json();
     expect(json.some((x) => x.platform === "linea")).toBe(true);
   });
-  it("It should response 200 data for linea,184.linea", async () => {
+  it("It should respond 200 data for linea,184.linea", async () => {
     const res = await queryClient("/ns/linea,184.linea");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.some((x) => x.platform === "linea")).toBe(true);
   });
-  it("It should response 200 data for solana,4JBz4tAKgAmxjDPHHi9HRLj14RsCQJyuCkCFKnpz7B9s", async () => {
+  it("It should respond 200 data for solana,4JBz4tAKgAmxjDPHHi9HRLj14RsCQJyuCkCFKnpz7B9s", async () => {
     const res = await queryClient(
       "/ns/4JBz4tAKgAmxjDPHHi9HRLj14RsCQJyuCkCFKnpz7B9s",
     );
@@ -71,7 +71,7 @@ describe("Test For Universal NS API", () => {
     const json = await res.json();
     expect(json[0].identity).toBe("v2ex.sol");
   });
-  it("It should response 200 data for 0x1af68a3cad9918056106d2ee77879489b56c2f80", async () => {
+  it("It should respond 200 data for 0x1af68a3cad9918056106d2ee77879489b56c2f80", async () => {
     const res = await queryClient(
       "/ns/0x1af68a3cad9918056106d2ee77879489b56c2f80",
     );
@@ -79,7 +79,7 @@ describe("Test For Universal NS API", () => {
     const json = await res.json();
     expect(json[0].platform).toBe("farcaster");
   });
-  it("It should response 200 data for 0x0caa7be0edbe2e65a4b06936782ef8fdf6de8b95", async () => {
+  it("It should respond 200 data for 0x0caa7be0edbe2e65a4b06936782ef8fdf6de8b95", async () => {
     const res = await queryClient(
       "/ns/0x0caa7be0edbe2e65a4b06936782ef8fdf6de8b95",
     );

--- a/__tests__/profile/basenames.test.js
+++ b/__tests__/profile/basenames.test.js
@@ -1,14 +1,14 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For BaseNames Profile API", () => {
-  it("It should response 200 for suji.base", async () => {
+  it("It should respond 200 for suji.base", async () => {
     const res = await queryClient("/profile/basenames/suji.base");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.createdAt).toBe("2024-08-22T06:32:25.000Z");
     expect(json.address).toBe("0xc9d18042baabe51d38297d1f3520cfbef0c83c32");
   });
-  it("It should response 200 for tony.base.eth", async () => {
+  it("It should respond 200 for tony.base.eth", async () => {
     const res = await queryClient("/profile/basenames/tony.base.eth");
     expect(res.status).toBe(200);
     const json = await res.json();

--- a/__tests__/profile/batch.test.js
+++ b/__tests__/profile/batch.test.js
@@ -14,7 +14,7 @@ describe("Test For Batch Query", () => {
     "ens,2️⃣2️⃣.eth",
   ];
 
-  it("It should response 200 for Batch Query GET", async () => {
+  it("It should respond 200 for Batch Query GET", async () => {
     const url = `/profile/batch/${encodeURIComponent(JSON.stringify(getIds))}`;
     const res = await queryClient(url);
     expect(res.status).toBe(200);

--- a/__tests__/profile/ens.test.js
+++ b/__tests__/profile/ens.test.js
@@ -1,7 +1,7 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For ENS Profile API", () => {
-  it("It should response 200 for brantly.eth", async () => {
+  it("It should respond 200 for brantly.eth", async () => {
     const res = await queryClient("/profile/ens/brantly.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -13,14 +13,14 @@ describe("Test For ENS Profile API", () => {
     expect(json.links.twitter.handle).toBe("brantlymillegan");
     expect(json.links.twitter.link).toBe("https://x.com/brantlymillegan");
   });
-  it("It should response 200 for dr3a.eth", async () => {
+  it("It should respond 200 for dr3a.eth", async () => {
     const res = await queryClient("/profile/ens/dr3a.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.links.lens).toBeTruthy();
     expect(json.links.farcaster).toBeTruthy();
   });
-  it("It should response 404 for xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.eth", async () => {
+  it("It should respond 404 for xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.eth", async () => {
     const res = await queryClient(
       "/profile/ens/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.eth",
     );
@@ -28,7 +28,7 @@ describe("Test For ENS Profile API", () => {
     const json = await res.json();
     expect(json.error).toBe("Invalid Resolved Address");
   });
-  it("It should response 200 for sujiyan.eth", async () => {
+  it("It should respond 200 for sujiyan.eth", async () => {
     const res = await queryClient("/profile/ens/sujiyan.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -38,19 +38,19 @@ describe("Test For ENS Profile API", () => {
     );
     expect(json.address).toBe("0x7cbba07e31dc7b12bb69a1209c5b11a8ac50acf5");
   });
-  it("It should response 200 for ricmoo.eth", async () => {
+  it("It should respond 200 for ricmoo.eth", async () => {
     const res = await queryClient("/profile/ens/ricmoo.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.links.github.handle).toBe("ricmoo");
   });
-  it("It should response 200 for tartu.eth", async () => {
+  it("It should respond 200 for tartu.eth", async () => {
     const res = await queryClient("/profile/ens/tartu.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBe("0x161ea288055b58fb182f72b124a5d0f367b099e4");
   });
-  it("It should response 404 for 0xcee81f7dd39d817f699a5c9eb93e3e6520f5b996", async () => {
+  it("It should respond 404 for 0xcee81f7dd39d817f699a5c9eb93e3e6520f5b996", async () => {
     const res = await queryClient(
       "/profile/ens/0xcee81f7dd39d817f699a5c9eb93e3e6520f5b996",
     );
@@ -58,7 +58,7 @@ describe("Test For ENS Profile API", () => {
     const json = await res.json();
     expect(json.identity).toBe("0xcee81f7dd39d817f699a5c9eb93e3e6520f5b996");
   });
-  it("It should response 404 for 0x000000000000000000000000000000000000dEaD", async () => {
+  it("It should respond 404 for 0x000000000000000000000000000000000000dEaD", async () => {
     const res = await queryClient(
       "/profile/ens/0x000000000000000000000000000000000000dEaD",
     );
@@ -66,26 +66,26 @@ describe("Test For ENS Profile API", () => {
     const json = await res.json();
     expect(json.error).toBe("Invalid Identity or Domain");
   });
-  it("It should response 404 for sujiyan.lens", async () => {
+  it("It should respond 404 for sujiyan.lens", async () => {
     const res = await queryClient("/profile/ens/sujiyan.lens");
     expect(res.status).toBe(404);
     const json = await res.json();
     expect(json.error).toBe("Invalid Identity or Domain");
   });
-  it("It should response 404 for gothgorl.eth", async () => {
+  it("It should respond 404 for gothgorl.eth", async () => {
     const res = await queryClient("/profile/ens/gothgorl.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.links.website.handle).toBe("linktr.ee/starcaster12");
   });
-  it("It should response 200 for offchainexample.eth", async () => {
+  it("It should respond 200 for offchainexample.eth", async () => {
     const res = await queryClient("/profile/ens/offchainexample.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBe("0xffd1ac3e8818adcbe5c597ea076e8d3210b45df5");
     // expect(json.email).toBeTruthy();
   });
-  it("It should response 200 for ethidfoundation.eth", async () => {
+  it("It should respond 200 for ethidfoundation.eth", async () => {
     const res = await queryClient("/profile/ens/ethidfoundation.eth");
     expect(res.status).toBe(200);
     const json = await res.json();

--- a/__tests__/profile/ethereum.test.js
+++ b/__tests__/profile/ethereum.test.js
@@ -1,14 +1,14 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Ethereum Profile API", () => {
-  it("It should response 200 for sio.eth", async () => {
+  it("It should respond 200 for sio.eth", async () => {
     const res = await queryClient("/profile/ethereum/sio.eth");
     const json = await res.json();
     const res2 = await queryClient("/profile/ens/sio.eth");
     const json2 = await res2.json();
     expect(json.address).toBe(json2.address);
   });
-  it("It should response 200 for 0xf4844a06d4f995c4c03195afcb5aa59dcbb5b4fc", async () => {
+  it("It should respond 200 for 0xf4844a06d4f995c4c03195afcb5aa59dcbb5b4fc", async () => {
     const res = await queryClient(
       "/profile/ethereum/0xf4844a06d4f995c4c03195afcb5aa59dcbb5b4fc",
     );
@@ -17,12 +17,12 @@ describe("Test For Ethereum Profile API", () => {
     const json2 = await res2.json();
     expect(json.address).toBe(json2.find((x) => x.platform === "ens").address);
   });
-  it("It should response 200 for gamedb.eth", async () => {
+  it("It should respond 200 for gamedb.eth", async () => {
     const res = await queryClient("/profile/ethereum/gamedb.eth");
     const json = await res.json();
     expect(json.address).toBe("0x18deee9699526f8c8a87004b2e4e55029fb26b9a");
   });
-  it("It should response 200 for 0x18deee9699526f8c8a87004b2e4e55029fb26b9a", async () => {
+  it("It should respond 200 for 0x18deee9699526f8c8a87004b2e4e55029fb26b9a", async () => {
     const res = await queryClient(
       "/profile/ethereum/0x18deee9699526f8c8a87004b2e4e55029fb26b9a",
     );
@@ -30,12 +30,12 @@ describe("Test For Ethereum Profile API", () => {
     expect(json.identity).toBe("planetable.eth");
     expect(json.createdAt).toBe("2022-02-15T11:02:56.000Z");
   });
-  it("It should response 200 for yisiliu.eth", async () => {
+  it("It should respond 200 for yisiliu.eth", async () => {
     const res = await queryClient("/profile/ethereum/yisiliu.eth");
     const json = await res.json();
     expect(json.platform).toBe("ens");
   });
-  it("It should response 404 for taoli.eth", async () => {
+  it("It should respond 404 for taoli.eth", async () => {
     const res = await queryClient("/profile/ethereum/taoli.eth");
     expect(res.status).toBe(200);
   });

--- a/__tests__/profile/farcaster.test.js
+++ b/__tests__/profile/farcaster.test.js
@@ -1,7 +1,7 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Farcaster Profile API", () => {
-  it("It should response 200 for suji", async () => {
+  it("It should respond 200 for suji", async () => {
     const res = await queryClient("/profile/farcaster/suji");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -9,7 +9,7 @@ describe("Test For Farcaster Profile API", () => {
     expect(json.links.twitter.handle).toBe("suji_yan");
     expect(json.links.twitter.sources.includes("farcaster")).toBeTruthy();
   });
-  it("It should response 200 for 0xc648dbbe0a20f850ff5ef2aa73ffb5a149befca2", async () => {
+  it("It should respond 200 for 0xc648dbbe0a20f850ff5ef2aa73ffb5a149befca2", async () => {
     const res = await queryClient(
       "/profile/farcaster/0xc648dbbe0a20f850ff5ef2aa73ffb5a149befca2",
     );
@@ -20,36 +20,36 @@ describe("Test For Farcaster Profile API", () => {
     expect(json.links.farcaster.handle).toBe("suji");
     expect(json.createdAt).toBe("2023-11-07T22:14:15.000Z");
   });
-  it("It should response 200 for farcaster", async () => {
+  it("It should respond 200 for farcaster", async () => {
     const res = await queryClient("/profile/farcaster/farcaster");
     expect(res.status).toBe(200);
     expect((await res.json()).displayName).toBe("Farcaster");
   });
-  it("It should response 404 for 💗", async () => {
+  it("It should respond 404 for 💗", async () => {
     const res = await queryClient("/profile/farcaster/💗");
     expect(res.status).toBe(404);
     const json = await res.json();
     expect(json.error).toBe("Invalid Identity or Domain");
   });
-  it("It should response 200 for july", async () => {
+  it("It should respond 200 for july", async () => {
     const res = await queryClient("/profile/farcaster/july");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBe("0xb2c42d93c1ec6c57b1713e03827369d59866e4b4");
   });
-  it("It should response 200 for dwr", async () => {
+  it("It should respond 200 for dwr", async () => {
     const res = await queryClient("/profile/farcaster/dwr");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.displayName).toBe("Dan Romero");
   });
-  it("It should response 200 for dwr.eth", async () => {
+  it("It should respond 200 for dwr.eth", async () => {
     const res = await queryClient("/profile/farcaster/dwr.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBe("0x6ce09ed5526de4afe4a981ad86d17b2f5c92fea5");
   });
-  it("It should response 200 for farcaster%2C%233", async () => {
+  it("It should respond 200 for farcaster%2C%233", async () => {
     const res = await queryClient("/profile/farcaster/farcaster%2C%233");
     expect(res.status).toBe(200);
     expect((await res.json()).identity).toBe("dwr");

--- a/__tests__/profile/lens.test.js
+++ b/__tests__/profile/lens.test.js
@@ -1,14 +1,14 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Lens Profile API", () => {
-  it("It should response 200 for sujiyan.lens", async () => {
+  it("It should respond 200 for sujiyan.lens", async () => {
     const res = await queryClient("/profile/lens/sujiyan.lens");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.links.lens.handle).toBe("sujiyan.lens");
     expect(json.address).toBe("0x9a96f14e39fe946014ff1a11540c4d4f7b441006");
   });
-  it("It should response 200 for stani.lens", async () => {
+  it("It should respond 200 for stani.lens", async () => {
     const res = await queryClient("/profile/lens/stani.lens");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -16,19 +16,19 @@ describe("Test For Lens Profile API", () => {
     expect(json.displayName).toBe("Stani");
     expect(json.address).toBe("0x7241dddec3a6af367882eaf9651b87e1c7549dff");
   });
-  it("It should response 404 for 0xxxxxxxxxx", async () => {
+  it("It should respond 404 for 0xxxxxxxxxx", async () => {
     const res = await queryClient("/profile/lens/0xxxxxxxxxx");
     expect(res.status).toBe(404);
     expect((await res.json()).error).toBe("Invalid Identity or Domain");
   });
-  it("It should response 404 for 0xc0074d4F69F4281d7a8EB4D266348BA9F7599E0A", async () => {
+  it("It should respond 404 for 0xc0074d4F69F4281d7a8EB4D266348BA9F7599E0A", async () => {
     const res = await queryClient(
       "/profile/lens/0xc0074d4F69F4281d7a8EB4D266348BA9F7599E0A",
     );
     expect(res.status).toBe(404);
     expect((await res.json()).error).toBe("Not Found");
   });
-  it("It should response 404 for sujiyan.eth", async () => {
+  it("It should respond 404 for sujiyan.eth", async () => {
     const res = await queryClient("/profile/lens/sujiyan.eth");
     expect(res.status).toBe(404);
     expect((await res.json()).error).toBe("Invalid Identity or Domain");

--- a/__tests__/profile/linea.test.js
+++ b/__tests__/profile/linea.test.js
@@ -1,25 +1,25 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Linea Profile API", () => {
-  it("It should response 200 for 184.linea.eth", async () => {
+  it("It should respond 200 for 184.linea.eth", async () => {
     const res = await queryClient("/profile/linea/184.linea");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBe("0xc28de09ad1a20737b92834943558ddfcc88d020d");
   });
-  it("It should response 200 for 0xthor.linea.eth", async () => {
+  it("It should respond 200 for 0xthor.linea.eth", async () => {
     const res = await queryClient("/profile/linea/0xthor");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.email).toBe("thorjr88@gmail.com");
   });
-  it("It should response 200 for alhemi.linea.eth", async () => {
+  it("It should respond 200 for alhemi.linea.eth", async () => {
     const res = await queryClient("/profile/linea/alhemi.linea.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBe("0x455c3b6b9f25e35b02037a28c3b6a6c8f1ab56c8");
   });
-  it("It should response 200 for 0xc28de09ad1a20737b92834943558ddfcc88d020d", async () => {
+  it("It should respond 200 for 0xc28de09ad1a20737b92834943558ddfcc88d020d", async () => {
     const res = await queryClient(
       "/profile/linea/0xc28de09ad1a20737b92834943558ddfcc88d020d",
     );
@@ -28,7 +28,7 @@ describe("Test For Linea Profile API", () => {
     expect(json.identity).toBe("184.linea.eth");
     expect(json.links.twitter.handle).toBe("184eth");
   });
-  it("It should response 200 for tacoz.linea.eth", async () => {
+  it("It should respond 200 for tacoz.linea.eth", async () => {
     const res = await queryClient("/profile/linea/tacoz.linea");
     expect(res.status).toBe(200);
     const json = await res.json();

--- a/__tests__/profile/sns.test.js
+++ b/__tests__/profile/sns.test.js
@@ -1,42 +1,42 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Solana Profile API", () => {
-  it("It should response 200 for bonfida.sol", async () => {
+  it("It should respond 200 for bonfida.sol", async () => {
     const res = await queryClient("/profile/sns/bonfida.sol");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBe("Fw1ETanDZafof7xEULsnq9UY6o71Tpds89tNwPkWLb1v");
   });
-  it("It should response 200 for 🍍.sol", async () => {
+  it("It should respond 200 for 🍍.sol", async () => {
     const res = await queryClient("/profile/sns/🍍.sol");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBe("8fe1EFcmz4BYeX6zGp6HUdoaHjVYhzsv599ub52WJbos");
     expect(json.displayName).toBeTruthy();
   });
-  it("It should response 200 for 7059.sol", async () => {
+  it("It should respond 200 for 7059.sol", async () => {
     const res = await queryClient("/profile/sns/7059.sol");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBeTruthy();
   });
-  it("It should response 200 for 0x33.sol", async () => {
+  it("It should respond 200 for 0x33.sol", async () => {
     const res = await queryClient("/profile/sns/0x33.sol");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.avatar).toBeTruthy();
   });
-  it("It should response 200 for lewsales.sol", async () => {
+  it("It should respond 200 for lewsales.sol", async () => {
     const res = await queryClient("/profile/sns/lewsales.sol");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.contenthash).toBe("ipfs://lewsales.blockchain");
   });
-  it("It should response 200 for anarcrypt.sol", async () => {
+  it("It should respond 200 for anarcrypt.sol", async () => {
     const res = await queryClient("/profile/sns/anarcrypt.sol");
     expect(res.status).toBe(200);
   });
-  it("It should response 200 for CHzTBh4fvhsszz1jrQhThtfVDBcLppaiwrhJ1dJGaXoK", async () => {
+  it("It should respond 200 for CHzTBh4fvhsszz1jrQhThtfVDBcLppaiwrhJ1dJGaXoK", async () => {
     const res = await queryClient(
       "/profile/sns/CHzTBh4fvhsszz1jrQhThtfVDBcLppaiwrhJ1dJGaXoK",
     );

--- a/__tests__/profile/solana.test.js
+++ b/__tests__/profile/solana.test.js
@@ -1,14 +1,14 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Solana Profile API", () => {
-  it("It should response 200 for sujiyan.sol", async () => {
+  it("It should respond 200 for sujiyan.sol", async () => {
     const res = await queryClient("/profile/solana/sujiyan.sol");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBe("2E3k7otC558kJJsK8wV8oehXf2VxPRQA3LtyW2mvF6w5");
     expect(json.platform).toBe("sns");
   });
-  it("It should response 200 for 46YaTaa8Xa1xFEVDxPa4CVJpzsNADocgixS51HLNCS4Y", async () => {
+  it("It should respond 200 for 46YaTaa8Xa1xFEVDxPa4CVJpzsNADocgixS51HLNCS4Y", async () => {
     const res = await queryClient(
       "/profile/solana/46YaTaa8Xa1xFEVDxPa4CVJpzsNADocgixS51HLNCS4Y",
     );

--- a/__tests__/profile/ud.test.js
+++ b/__tests__/profile/ud.test.js
@@ -1,7 +1,7 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Unstoppable Domains Profile API", () => {
-  it("It should response 200 for 0x0da0ee86269797618032e56a69b1aad095c581fc", async () => {
+  it("It should respond 200 for 0x0da0ee86269797618032e56a69b1aad095c581fc", async () => {
     const res = await queryClient(
       "/profile/unstoppabledomains/0x0da0ee86269797618032e56a69b1aad095c581fc",
     );
@@ -11,7 +11,7 @@ describe("Test For Unstoppable Domains Profile API", () => {
     expect(json.links.website.sources.includes("keybase")).toBeTruthy();
     expect(json.address).toBe("0x0da0ee86269797618032e56a69b1aad095c581fc");
   });
-  it("It should response 200 for sandy.nft", async () => {
+  it("It should respond 200 for sandy.nft", async () => {
     const res = await queryClient("/profile/unstoppabledomains/sandy.nft");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -20,17 +20,17 @@ describe("Test For Unstoppable Domains Profile API", () => {
       "ipfs://Qmar8DH5xBihbGU449zKAg4sx7ahHbFZgksYHKBFFhfVq7",
     );
   });
-  it("It should response 200 for al.x", async () => {
+  it("It should respond 200 for al.x", async () => {
     const res = await queryClient("/profile/unstoppabledomains/al.x");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.address).toBe("0x2ccff304ef578b238ee82e1d1d53c34e80b48ad6");
   });
-  it("It should response 404 for sujiyan.eth", async () => {
+  it("It should respond 404 for sujiyan.eth", async () => {
     const res = await queryClient("/profile/unstoppabledomains/sujiyan.eth");
     expect(res.status).toBe(404);
   });
-  it("It should response 404 for nyk.app", async () => {
+  it("It should respond 404 for nyk.app", async () => {
     const res = await queryClient("/profile/unstoppabledomains/nyk.app");
     expect(res.status).toBe(404);
   });

--- a/__tests__/profile/universal.test.js
+++ b/__tests__/profile/universal.test.js
@@ -1,7 +1,7 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Universal Profile API", () => {
-  it("It should response 200 data for 0x7cbba07e31dc7b12bb69a1209c5b11a8ac50acf5", async () => {
+  it("It should respond 200 data for 0x7cbba07e31dc7b12bb69a1209c5b11a8ac50acf5", async () => {
     const res = await queryClient(
       "/profile/0x7cbba07e31dc7b12bb69a1209c5b11a8ac50acf5",
     );
@@ -11,7 +11,7 @@ describe("Test For Universal Profile API", () => {
     expect(json[0].displayName).toBe("sujiyan.eth");
     expect(json[1].platform).toBe("basenames");
   });
-  it("It should response 200 data for lilgho.lens", async () => {
+  it("It should respond 200 data for lilgho.lens", async () => {
     const res = await queryClient("/profile/lilgho.lens");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -20,7 +20,7 @@ describe("Test For Universal Profile API", () => {
     expect(json[1].platform).toBe("lens");
     expect(json.length).toBe(11);
   });
-  it("It should response 200 data for 0x7241dddec3a6af367882eaf9651b87e1c7549dff", async () => {
+  it("It should respond 200 data for 0x7241dddec3a6af367882eaf9651b87e1c7549dff", async () => {
     const res = await queryClient(
       "/profile/0x7241dddec3a6af367882eaf9651b87e1c7549dff",
     );
@@ -28,13 +28,13 @@ describe("Test For Universal Profile API", () => {
     const json = await res.json();
     expect(json.some((x) => x.identity === "stani.lens")).toBe(true);
   });
-  it("It should response 200 data for noun124.eth", async () => {
+  it("It should respond 200 data for noun124.eth", async () => {
     const res = await queryClient("/profile/noun124.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json[0].identity).toBe("noun124.eth");
   });
-  it("It should response 200 data for 0x3ddfa8ec3052539b6c9549f12cea2c295cff5296", async () => {
+  it("It should respond 200 data for 0x3ddfa8ec3052539b6c9549f12cea2c295cff5296", async () => {
     const res = await queryClient(
       "/profile/0x3ddfa8ec3052539b6c9549f12cea2c295cff5296",
     );
@@ -44,7 +44,7 @@ describe("Test For Universal Profile API", () => {
     expect(json.length).toBe(1);
   });
 
-  it("It should response 200 for sujiyan.eth", async () => {
+  it("It should respond 200 for sujiyan.eth", async () => {
     const res = await queryClient("/profile/sujiyan.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -56,13 +56,13 @@ describe("Test For Universal Profile API", () => {
       json.find((x) => x.platform === "farcaster").social.follower,
     ).toBeTruthy();
   });
-  it("It should response 200 for mcdonalds.eth", async () => {
+  it("It should respond 200 for mcdonalds.eth", async () => {
     const res = await queryClient("/profile/mcdonalds.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json[0].address).toBe("0x782cf6b6e735496f7e608489b0c57ee27f407e7d");
   });
-  it("It should response 200 data for stani.lens", async () => {
+  it("It should respond 200 data for stani.lens", async () => {
     const res = await queryClient("/profile/stani.lens");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -71,7 +71,7 @@ describe("Test For Universal Profile API", () => {
       json.find((x) => x.platform === "lens").social.following,
     ).toBeTruthy();
   });
-  it("It should response 200 data for brantly.eth", async () => {
+  it("It should respond 200 data for brantly.eth", async () => {
     const res = await queryClient("/profile/brantly.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -86,7 +86,7 @@ describe("Test For Universal Profile API", () => {
     expect(isValidHandle).toBe(true);
     expect(links.length).toBe(4);
   });
-  it("It should response 200 data for 0x934b510d4c9103e6a87aef13b816fb080286d649", async () => {
+  it("It should respond 200 data for 0x934b510d4c9103e6a87aef13b816fb080286d649", async () => {
     const res = await queryClient(
       "/profile/0x934b510d4c9103e6a87aef13b816fb080286d649",
     );
@@ -94,7 +94,7 @@ describe("Test For Universal Profile API", () => {
     const json = await res.json();
     expect(json[0].platform).toBe("lens");
   });
-  it("It should response 200 data for 0xE0b3Ef5A61324acceE3798B6D9Da5B47b0312b7c", async () => {
+  it("It should respond 200 data for 0xE0b3Ef5A61324acceE3798B6D9Da5B47b0312b7c", async () => {
     const res = await queryClient(
       "/profile/0xE0b3Ef5A61324acceE3798B6D9Da5B47b0312b7c",
     );
@@ -103,7 +103,7 @@ describe("Test For Universal Profile API", () => {
     expect(json.filter((x) => x.platform === "lens").length > 1);
   });
 
-  it("It should response 200 data for 0x638b1350920333d23a7a7472c00aa5c38c278b90", async () => {
+  it("It should respond 200 data for 0x638b1350920333d23a7a7472c00aa5c38c278b90", async () => {
     const res = await queryClient(
       "/profile/0x638b1350920333d23a7a7472c00aa5c38c278b90",
     );
@@ -111,13 +111,13 @@ describe("Test For Universal Profile API", () => {
     const json = await res.json();
     expect(json.find((x) => x.platform === "ens")).toBeTruthy();
   });
-  it("It should response 200 data for gamedb.eth", async () => {
+  it("It should respond 200 data for gamedb.eth", async () => {
     const res = await queryClient("/profile/gamedb.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.find((x) => x.platform === "ens").identity).toBe("gamedb.eth");
   });
-  it("It should response 200 data for livid.farcaster", async () => {
+  it("It should respond 200 data for livid.farcaster", async () => {
     const res = await queryClient("/profile/livid.farcaster");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -126,39 +126,39 @@ describe("Test For Universal Profile API", () => {
       json.find((x) => x.platform === "farcaster").links.twitter.handle,
     ).toBe("livid");
   });
-  it("It should response 200 data for griff.eth.farcaster", async () => {
+  it("It should respond 200 data for griff.eth.farcaster", async () => {
     const res = await queryClient("/profile/griff.eth.farcaster");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json[0].platform).toBe("farcaster");
   });
-  it("It should response 200 data for аррӏе.eth", async () => {
+  it("It should respond 200 data for аррӏе.eth", async () => {
     const res = await queryClient("/profile/аррӏе.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.find((x) => x.platform === "farcaster").identity).toBe("123-");
     expect(json.length > 1).toBeTruthy();
   });
-  it("It should response 404 data for sujiyan.bnb", async () => {
+  it("It should respond 404 data for sujiyan.bnb", async () => {
     const res = await queryClient("/profile/sujiyan.bnb");
     expect(res.status).toBe(404);
     const json = await res.json();
     expect(json.error).toBe("Invalid Identity or Domain");
   });
-  it("It should response 200 data for shoni.eth", async () => {
+  it("It should respond 200 data for shoni.eth", async () => {
     const res = await queryClient("/profile/shoni.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json[0].identity).toBe("shoni.eth");
   });
 
-  it("It should response 200 for suji_yan.twitter", async () => {
+  it("It should respond 200 for suji_yan.twitter", async () => {
     const res = await queryClient("/profile/twitter,suji_yan");
     const json = await res.json();
     expect(json[0].platform).toBe("ens");
     expect(json[0].identity).toBe("sujiyan.eth");
   });
-  it("It should response 200 for nextid,0x027e55e1b78e873c6f7d585064b41cd2735000bacc0092fe947c11ab7742ed351f", async () => {
+  it("It should respond 200 for nextid,0x027e55e1b78e873c6f7d585064b41cd2735000bacc0092fe947c11ab7742ed351f", async () => {
     const res = await queryClient(
       "/profile/nextid,0x027e55e1b78e873c6f7d585064b41cd2735000bacc0092fe947c11ab7742ed351f",
     );
@@ -166,7 +166,7 @@ describe("Test For Universal Profile API", () => {
     expect(json[0].platform).toBe("ens");
     expect(json.some((x) => x.platform === "nextid")).toBe(false);
   });
-  it("It should response 200 for 8iK1d14zA54SR6bWuzAwbRTcUpMLQCHyN5zv7rWo5ZFL.nextid", async () => {
+  it("It should respond 200 for 8iK1d14zA54SR6bWuzAwbRTcUpMLQCHyN5zv7rWo5ZFL.nextid", async () => {
     const res = await queryClient(
       "/profile/8iK1d14zA54SR6bWuzAwbRTcUpMLQCHyN5zv7rWo5ZFL",
     );
@@ -176,7 +176,7 @@ describe("Test For Universal Profile API", () => {
     );
   });
   // test sort for emoji 🦊%EF%B8%8F🦊%EF%B8%8F🦊%EF%B8%8F.eth
-  it("It should response 200 for %F0%9F%A6%8A%EF%B8%8F%F0%9F%A6%8A%EF%B8%8F%F0%9F%A6%8A%EF%B8%8F.eth", async () => {
+  it("It should respond 200 for %F0%9F%A6%8A%EF%B8%8F%F0%9F%A6%8A%EF%B8%8F%F0%9F%A6%8A%EF%B8%8F.eth", async () => {
     const res = await queryClient(
       "/profile/%F0%9F%A6%8A%EF%B8%8F%F0%9F%A6%8A%EF%B8%8F%F0%9F%A6%8A%EF%B8%8F.eth",
     );
@@ -184,19 +184,19 @@ describe("Test For Universal Profile API", () => {
     const json = await res.json();
     expect(json[0].identity).toBe("🦊🦊🦊.eth");
   });
-  it("It should response 200 for filelly.eth", async () => {
+  it("It should respond 200 for filelly.eth", async () => {
     const res = await queryClient("/profile/filelly.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json[0].address).toBe("0xea1c2886d9cb0c3b119cd145c9c1a6bc1f26f150");
   });
-  it("It should response 200 for 30315.eth", async () => {
+  it("It should respond 200 for 30315.eth", async () => {
     const res = await queryClient("/profile/30315.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json[0].identity).toBe("30315.eth");
   });
-  it("It should response 200 for farcaster,0x7cbba07e31dc7b12bb69a1209c5b11a8ac50acf5", async () => {
+  it("It should respond 200 for farcaster,0x7cbba07e31dc7b12bb69a1209c5b11a8ac50acf5", async () => {
     const res = await queryClient(
       "/profile/farcaster,0x7cbba07e31dc7b12bb69a1209c5b11a8ac50acf5",
     );
@@ -205,7 +205,7 @@ describe("Test For Universal Profile API", () => {
     expect(json[0].platform).toBe("farcaster");
     expect(json[0].identity).toBe("suji");
   });
-  it("It should response 200 for krys.eth", async () => {
+  it("It should respond 200 for krys.eth", async () => {
     const res = await queryClient("/profile/krys.eth");
     expect(res.status).toBe(200);
     const json = await res.json();

--- a/__tests__/profile/universal.test.js
+++ b/__tests__/profile/universal.test.js
@@ -92,7 +92,7 @@ describe("Test For Universal Profile API", () => {
     );
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json[0].platform).toBe("ethereum");
+    expect(json[0].platform).toBe("lens");
   });
   it("It should response 200 data for 0xE0b3Ef5A61324acceE3798B6D9Da5B47b0312b7c", async () => {
     const res = await queryClient(
@@ -158,9 +158,9 @@ describe("Test For Universal Profile API", () => {
     expect(json[0].platform).toBe("ens");
     expect(json[0].identity).toBe("sujiyan.eth");
   });
-  it("It should response 200 for 0x027e55e1b78e873c6f7d585064b41cd2735000bacc0092fe947c11ab7742ed351f.nextid", async () => {
+  it("It should response 200 for nextid,0x027e55e1b78e873c6f7d585064b41cd2735000bacc0092fe947c11ab7742ed351f", async () => {
     const res = await queryClient(
-      "/profile/0x027e55e1b78e873c6f7d585064b41cd2735000bacc0092fe947c11ab7742ed351f.nextid",
+      "/profile/nextid,0x027e55e1b78e873c6f7d585064b41cd2735000bacc0092fe947c11ab7742ed351f",
     );
     const json = await res.json();
     expect(json[0].platform).toBe("ens");

--- a/__tests__/profile/web2.test.js
+++ b/__tests__/profile/web2.test.js
@@ -1,7 +1,7 @@
 import { queryClient } from "../../utils/test-utils";
 
 describe("Test For Profile Web2 API", () => {
-  it("It should response 200 for sujiyan.eth", async () => {
+  it("It should respond 200 for sujiyan.eth", async () => {
     const res = await queryClient("/profile/web2/sujiyan.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -12,15 +12,15 @@ describe("Test For Profile Web2 API", () => {
       json.find((x) => x.platform === "instagram").links.website.handle,
     ).toBe("dimension.im");
   });
-  it("It should response 200 for accountless.eth", async () => {
+  it("It should respond 200 for accountless.eth", async () => {
     const res = await queryClient("/profile/web2/accountless.eth");
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(
-      json.find((x) => x.platform === "ens").links.website.handle,
-    ).toBe("linktr.ee/alexanderchopan");
-    expect(
-      json.find((x) => x.platform === "github").links.website.handle,
-    ).toBe("linktr.ee/alexanderchopan");
+    expect(json.find((x) => x.platform === "ens").links.website.handle).toBe(
+      "linktr.ee/alexanderchopan",
+    );
+    expect(json.find((x) => x.platform === "github").links.website.handle).toBe(
+      "linktr.ee/alexanderchopan",
+    );
   });
 });

--- a/__tests__/wallet.test.js
+++ b/__tests__/wallet.test.js
@@ -1,7 +1,7 @@
 import { queryClient } from "../utils/test-utils";
 
 describe("Test For Wallet API query", () => {
-  it("It should response 200 for 0xcd133d337ead9c2ac799ec7524a1e0f8aa30c3b1", async () => {
+  it("It should respond 200 for 0xcd133d337ead9c2ac799ec7524a1e0f8aa30c3b1", async () => {
     const res = await queryClient(
       "/wallet/0xcd133d337ead9c2ac799ec7524a1e0f8aa30c3b1",
     );
@@ -10,7 +10,7 @@ describe("Test For Wallet API query", () => {
     expect(json.displayName).toBe("0xhelena.eth");
     expect(json.domains.length).toBeGreaterThanOrEqual(2);
   });
-  it("It should response 200 for 0xf4844a06d4f995c4c03195afcb5aa59dcbb5b4fc", async () => {
+  it("It should respond 200 for 0xf4844a06d4f995c4c03195afcb5aa59dcbb5b4fc", async () => {
     const res = await queryClient(
       "/wallet/0xf4844a06d4f995c4c03195afcb5aa59dcbb5b4fc",
     );
@@ -19,13 +19,13 @@ describe("Test For Wallet API query", () => {
     expect(json.domains.some((x) => x.identity === "wijuwiju.eth")).toBe(true);
     expect(json.credential.isHuman.length).toBeGreaterThanOrEqual(1);
   });
-  it("It should response 200 for suji.farcaster", async () => {
+  it("It should respond 200 for suji.farcaster", async () => {
     const res = await queryClient("/wallet/suji.farcaster");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.credential.isHuman).toBeTruthy();
   });
-  it("It should response 200 for 0xb8c2c29ee19d8307cb7255e1cd9cbde883a267d5", async () => {
+  it("It should respond 200 for 0xb8c2c29ee19d8307cb7255e1cd9cbde883a267d5", async () => {
     const res = await queryClient(
       "/wallet/0xb8c2c29ee19d8307cb7255e1cd9cbde883a267d5",
     );

--- a/__tests__/web2.test.js
+++ b/__tests__/web2.test.js
@@ -1,54 +1,54 @@
 import { queryClient } from "../utils/test-utils";
 
 describe("Test For NS API web2 query", () => {
-  it("It should response 200 for nostr,sujiyan", async () => {
+  it("It should respond 200 for nostr,sujiyan", async () => {
     const res = await queryClient("/ns/nostr,yuopu6");
     // single identity
     expect(res.status).toBe(404);
   });
-  it("It should response 200 for tedko.github", async () => {
+  it("It should respond 200 for tedko.github", async () => {
     const res = await queryClient("/ns/tedko.github");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json[0].identity).toBe("sujiyan.eth");
   });
-  it("It should response 200 for nicksdjohnson.twitter", async () => {
+  it("It should respond 200 for nicksdjohnson.twitter", async () => {
     const res = await queryClient("/ns/nicksdjohnson.twitter");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json[0].identity).toBe("nick.eth");
   });
-  it("It should response 200 for sujiyan.discord", async () => {
+  it("It should respond 200 for sujiyan.discord", async () => {
     const res = await queryClient("/ns/sujiyan.discord");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json[0].identity).toBe("sujiyan.eth");
   });
-  it("It should response 200 for wgmeets.instagram", async () => {
+  it("It should respond 200 for wgmeets.instagram", async () => {
     const res = await queryClient("/ns/wgmeets.instagram");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json[0].identity).toBe("wgmeets.eth");
   });
-  it("It should response 200 for jktedko.reddit", async () => {
+  it("It should respond 200 for jktedko.reddit", async () => {
     const res = await queryClient("/ns/jktedko.reddit");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json[0].identity).toBe("sujiyan.eth");
   });
-  it("It should response 200 for 0xhelena.bluesky", async () => {
+  it("It should respond 200 for 0xhelena.bluesky", async () => {
     const res = await queryClient("/ns/0xhelena.bluesky");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.some((x) => x.identity === "0xhelena.eth")).toBeTruthy();
   });
-  it("It should response 200 for benzweerachat.linkedin", async () => {
+  it("It should respond 200 for benzweerachat.linkedin", async () => {
     const res = await queryClient("/ns/benzweerachat.linkedin");
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json[0].identity).toBe("cbenz.eth");
   });
-  it("It should response 200 for igorls.facebook", async () => {
+  it("It should respond 200 for igorls.facebook", async () => {
     const res = await queryClient("/ns/igorls.facebook");
     // others all web2
     expect(res.status).toBe(404);

--- a/app/api/profile/[handle]/utils.ts
+++ b/app/api/profile/[handle]/utils.ts
@@ -388,6 +388,30 @@ const sortProfilesByPriority = (
   }
 
   const tail = includeWeb2Platforms ? nonPriorityProfiles : [];
+  const sourceAddress =
+    exactMatchProfile?.address ||
+    ((primaryPlatform === Platform.ethereum ||
+      primaryPlatform === Platform.solana) &&
+    isWeb3Address(targetHandle)
+      ? targetHandle
+      : "");
+
+  if (sourceAddress) {
+    const addressMatchedProfiles = sortedProfiles.filter((profile) =>
+      isSameAddress(profile.address, sourceAddress),
+    );
+    const addressUnmatchedProfiles = sortedProfiles.filter(
+      (profile) => !isSameAddress(profile.address, sourceAddress),
+    );
+    const reorderedProfiles = [
+      ...addressMatchedProfiles,
+      ...addressUnmatchedProfiles,
+    ];
+    return exactMatchProfile
+      ? [exactMatchProfile, ...reorderedProfiles, ...tail]
+      : [...reorderedProfiles, ...tail];
+  }
+
   return exactMatchProfile
     ? [exactMatchProfile, ...sortedProfiles, ...tail]
     : [...sortedProfiles, ...tail];

--- a/app/api/search/availability/[handle]/route.ts
+++ b/app/api/search/availability/[handle]/route.ts
@@ -1,11 +1,5 @@
 import { getQuery, QueryType } from "@/utils/query";
-import { AuthHeaders } from "@/utils/types";
-import {
-  errorHandle,
-  getUserHeaders,
-  IDENTITY_GRAPH_SERVER,
-  respondJson,
-} from "@/utils/utils";
+import { errorHandle, respondJson } from "@/utils/utils";
 import type { NextRequest } from "next/server";
 import { ErrorMessages } from "web3bio-profile-kit/types";
 
@@ -26,15 +20,12 @@ interface GraphQLResponse {
   msg?: string;
 }
 
-const queryDomains = async (
-  handle: string,
-  headers: AuthHeaders,
-): Promise<GraphQLResponse> => {
-  const response = await fetch(IDENTITY_GRAPH_SERVER, {
+const queryDomains = async (handle: string): Promise<GraphQLResponse> => {
+  const response = await fetch(process.env.GRAPHQL_SERVER || "", {
     method: "POST",
     headers: {
-      ...headers,
       "Content-Type": "application/json",
+      "x-api-key": process.env.WEB3BIO_API_KEY || "",
     },
     body: JSON.stringify({
       query: getQuery(QueryType.GET_AVAILABLE_DOMAINS),
@@ -66,19 +57,27 @@ export async function GET(
   }
 
   const trimmedHandle = handle.trim();
-  const headers = getUserHeaders(req.headers);
-  try {
-    const result = await queryDomains(trimmedHandle, headers);
 
-    if (result.errors || result.code) {
+  try {
+    const result = await queryDomains(trimmedHandle);
+
+    if (result.errors) {
       return errorHandle({
         identity: trimmedHandle,
         platform: null,
         path: pathname,
-        message: result.errors
-          ? "GraphQL query failed"
-          : result.msg || ErrorMessages.NOT_FOUND,
-        code: result.code || 500,
+        message: "GraphQL query failed",
+        code: 500,
+      });
+    }
+
+    if (result.code) {
+      return errorHandle({
+        identity: trimmedHandle,
+        platform: null,
+        path: pathname,
+        message: result.msg || ErrorMessages.NOT_FOUND,
+        code: result.code,
       });
     }
 

--- a/app/api/search/availability/[handle]/route.ts
+++ b/app/api/search/availability/[handle]/route.ts
@@ -1,5 +1,6 @@
 import { getQuery, QueryType } from "@/utils/query";
-import { errorHandle, respondJson } from "@/utils/utils";
+import { AuthHeaders } from "@/utils/types";
+import { errorHandle, getUserHeaders, respondJson } from "@/utils/utils";
 import type { NextRequest } from "next/server";
 import { ErrorMessages } from "web3bio-profile-kit/types";
 
@@ -20,12 +21,15 @@ interface GraphQLResponse {
   msg?: string;
 }
 
-const queryDomains = async (handle: string): Promise<GraphQLResponse> => {
+const queryDomains = async (
+  handle: string,
+  headers: AuthHeaders,
+): Promise<GraphQLResponse> => {
   const response = await fetch(process.env.GRAPHQL_SERVER || "", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "x-api-key": process.env.WEB3BIO_API_KEY || "",
+      ...headers,
     },
     body: JSON.stringify({
       query: getQuery(QueryType.GET_AVAILABLE_DOMAINS),
@@ -57,9 +61,10 @@ export async function GET(
   }
 
   const trimmedHandle = handle.trim();
+  const headers = getUserHeaders(req.headers);
 
   try {
-    const result = await queryDomains(trimmedHandle);
+    const result = await queryDomains(trimmedHandle, headers);
 
     if (result.errors) {
       return errorHandle({

--- a/app/api/search/availability/[handle]/route.ts
+++ b/app/api/search/availability/[handle]/route.ts
@@ -1,56 +1,29 @@
-import { getQuery, QueryType } from "@/utils/query";
-import { AuthHeaders } from "@/utils/types";
-import { errorHandle, getUserHeaders, respondJson } from "@/utils/utils";
 import type { NextRequest } from "next/server";
 import { ErrorMessages } from "web3bio-profile-kit/types";
+import {
+  getQuery,
+  identityGraphErrorMessage,
+  identityGraphErrorStatus,
+  postIdentityGraphQuery,
+  QueryType,
+} from "@/utils/query";
+import { errorHandle, getUserHeaders, respondJson } from "@/utils/utils";
 
-interface DomainAvailabilityResponse {
-  platform: string;
-  name: string;
-  expiredAt: string | null;
-  availability: boolean;
-  status: string;
-}
-
-interface GraphQLResponse {
-  data?: {
-    domainAvailableSearch: DomainAvailabilityResponse[];
-  };
+interface GraphQLEnvelope {
+  data?: unknown;
   errors?: unknown;
   code?: number;
   msg?: string;
 }
 
-const queryDomains = async (
-  handle: string,
-  headers: AuthHeaders,
-): Promise<GraphQLResponse> => {
-  const response = await fetch(process.env.GRAPHQL_SERVER || "", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...headers,
-    },
-    body: JSON.stringify({
-      query: getQuery(QueryType.GET_AVAILABLE_DOMAINS),
-      variables: { name: handle },
-    }),
-  });
-  if (!response.ok) {
-    throw new Error(`GraphQL request failed: ${response.status}`);
-  }
-
-  return response.json();
-};
-
 export async function GET(
   req: NextRequest,
-  props: { params: Promise<{ handle: string }> },
-): Promise<Response> {
+  { params }: { params: Promise<{ handle: string }> },
+) {
   const { pathname } = req.nextUrl;
-  const { handle } = await props.params;
+  const handle = (await params).handle?.trim() ?? "";
 
-  if (!handle || typeof handle !== "string" || handle.trim().length === 0) {
+  if (!handle) {
     return errorHandle({
       identity: null,
       path: pathname,
@@ -60,43 +33,35 @@ export async function GET(
     });
   }
 
-  const trimmedHandle = handle.trim();
   const headers = getUserHeaders(req.headers);
 
   try {
-    const result = await queryDomains(trimmedHandle, headers);
+    const { ok, status, body } = await postIdentityGraphQuery(
+      headers,
+      getQuery(QueryType.GET_AVAILABLE_DOMAINS),
+      { name: handle },
+    );
 
-    if (result.errors) {
+    const result = body as GraphQLEnvelope | null;
+
+    if (!ok || !result || result.code || result.errors) {
       return errorHandle({
-        identity: trimmedHandle,
+        identity: handle,
         platform: null,
         path: pathname,
-        message: "GraphQL query failed",
-        code: 500,
-      });
-    }
-
-    if (result.code) {
-      return errorHandle({
-        identity: trimmedHandle,
-        platform: null,
-        path: pathname,
-        message: result.msg || ErrorMessages.NOT_FOUND,
-        code: result.code,
+        message: identityGraphErrorMessage(result, ErrorMessages.NOT_FOUND),
+        code: identityGraphErrorStatus(ok, status, result?.code),
       });
     }
 
     return respondJson(result);
-  } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : "Unknown error occurred";
-
+  } catch (e: unknown) {
     return errorHandle({
-      identity: trimmedHandle,
+      identity: handle,
       platform: null,
       path: pathname,
-      message: errorMessage,
-      code: 500,
+      message: e instanceof Error ? e.message : ErrorMessages.NOT_FOUND,
+      code: e instanceof Error ? Number(e.cause) || 500 : 500,
     });
   }
 }

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,27 +1,14 @@
-import { queryIdentityGraph, QueryType } from "@/utils/query";
+import type { NextRequest } from "next/server";
+import { ErrorMessages, Platform } from "web3bio-profile-kit/types";
+import { isWeb2Platform } from "web3bio-profile-kit/utils";
 import { resolveEipAssetURL } from "@/utils/resolver";
 import {
   IdentityGraphQueryResponse,
   IdentityRecord,
   ProfileRecord,
 } from "@/utils/types";
-import { errorHandle, getUserHeaders, respondJson } from "@/utils/utils";
-import type { NextRequest } from "next/server";
-import { Platform, ErrorMessages } from "web3bio-profile-kit/types";
-
-const SEARCH_WEB2_LIST = [
-  Platform.twitter,
-  Platform.github,
-  Platform.discord,
-  Platform.keybase,
-  Platform.reddit,
-  Platform.instagram,
-  Platform.linkedin,
-];
-
-const isWeb2Platform = (platform: string) => {
-  return SEARCH_WEB2_LIST.includes(platform as Platform);
-};
+import { errorHandle, respondJson } from "@/utils/utils";
+import { getQuery, QueryType } from "@/utils/query";
 
 const processProfileAvatar = async (
   profile: ProfileRecord,
@@ -41,53 +28,62 @@ const processJson = async (json: IdentityGraphQueryResponse) => {
 
   if (!identity) return _json;
 
-  const promises: Promise<any>[] = [];
+  const avatarTasks: Promise<void>[] = [];
 
-  // Process main identity avatar
-  if (identity.profile) {
-    promises.push(
+  if (identity.profile?.avatar) {
+    avatarTasks.push(
       processProfileAvatar(identity.profile).then((processedAvatar) => {
         identity.profile.avatar = processedAvatar;
       }),
     );
   }
 
-  const vertices: IdentityRecord[] = identity.identityGraph?.vertices || [];
+  const isRemovedNode = (v: IdentityRecord) =>
+    v.platform === Platform.clusters && v.identity.includes("/");
 
-  if (vertices.length > 0) {
-    // Find current identity in vertices
-    const currentIndex = vertices.findIndex(
-      (vertex) =>
-        vertex.identity === identity.identity &&
-        vertex.platform === identity.platform,
+  const filteredNodes = new Set(
+    identity.identityGraph?.vertices
+      ?.filter(isRemovedNode)
+      .map((v) => `${v.platform},${v.identity}`) || [],
+  );
+
+  if (filteredNodes.size > 0 && identity.identityGraph) {
+    const graph = identity.identityGraph;
+    graph.vertices = graph.vertices?.filter((v) => !isRemovedNode(v));
+    graph.edges = graph.edges?.filter(
+      (e) => !filteredNodes.has(e.source) && !filteredNodes.has(e.target),
     );
-
-    // Ensure current identity is at the front
-    if (currentIndex === -1) {
-      // Current identity not in vertices, add it at the beginning
-      const currentIdentity = { ...identity };
-      delete currentIdentity.identityGraph;
-      vertices.unshift(currentIdentity);
-    } else if (currentIndex > 0) {
-      // Current identity exists but not at front, move it to front
-      const [currentIdentity] = vertices.splice(currentIndex, 1);
-      vertices.unshift(currentIdentity);
-    }
-
-    // Process avatars for all vertices with profiles
-    const avatarPromises = vertices
-      .filter((vertex) => vertex?.profile?.avatar)
-      .map(async (vertex) => {
-        const processedAvatar = await processProfileAvatar(vertex.profile);
-        vertex.profile.avatar = processedAvatar;
-      });
-
-    if (avatarPromises.length > 0) {
-      promises.push(Promise.allSettled(avatarPromises));
-    }
   }
 
-  await Promise.allSettled(promises);
+  const vertices: IdentityRecord[] = identity.identityGraph?.vertices || [];
+  if (vertices.length > 0) {
+    const currentIndex = vertices.findIndex(
+      (v) =>
+        v.identity === identity.identity && v.platform === identity.platform,
+    );
+    const currentKey = `${identity.platform},${identity.identity}`;
+
+    if (currentIndex === -1 && !filteredNodes.has(currentKey)) {
+      const { identityGraph, ...currentIdentity } = identity;
+      vertices.unshift(currentIdentity as IdentityRecord);
+    } else if (currentIndex > 0) {
+      vertices.unshift(...vertices.splice(currentIndex, 1));
+    }
+
+    vertices
+      .filter((v) => v?.profile?.avatar)
+      .forEach((v) => {
+        avatarTasks.push(
+          processProfileAvatar(v.profile).then((processedAvatar) => {
+            v.profile.avatar = processedAvatar;
+          }),
+        );
+      });
+  }
+
+  if (avatarTasks.length > 0) {
+    await Promise.allSettled(avatarTasks);
+  }
   return _json;
 };
 
@@ -95,56 +91,60 @@ export async function GET(req: NextRequest) {
   const { searchParams, pathname } = req.nextUrl;
   const identity = searchParams.get("identity");
   const platform = searchParams.get("platform") as Platform;
-  if (!identity || !platform)
+
+  if (!identity || !platform) {
     return errorHandle({
-      identity: identity,
+      identity,
       path: pathname,
-      platform: platform,
+      platform,
       code: 404,
       message: ErrorMessages.INVALID_IDENTITY,
     });
-  const headers = getUserHeaders(req.headers);
-
+  }
   try {
-    const res = await queryIdentityGraph(
-      QueryType.GET_SEARCH_QUERY,
-      identity,
-      platform,
-      headers,
-    );
+    const rawJson = await fetch(process.env.GRAPHQL_SERVER || "", {
+      method: "POST",
+      headers: {
+        "x-api-key": process.env.WEB3BIO_API_KEY || "",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: getQuery(QueryType.GET_SEARCH_QUERY),
+        variables: { identity, platform },
+      }),
+    }).then((res) => res.json());
 
-    if (res?.code || res?.errors) {
+    if (rawJson?.code || rawJson?.errors) {
       return errorHandle({
-        identity: identity,
+        identity,
         path: pathname,
-        platform: platform,
-        code: res.code,
-        message: res.msg
-          ? res.msg
-          : res.errors
-            ? JSON.stringify(res.errors)
-            : ErrorMessages.NOT_FOUND,
+        platform,
+        code: rawJson.code,
+        message:
+          rawJson.msg ||
+          (rawJson.errors
+            ? JSON.stringify(rawJson.errors)
+            : ErrorMessages.NOT_FOUND),
       });
     }
 
-    if (isSingleWeb2Identity(res.data.identity)) {
+    if (isSingleWeb2Identity(rawJson.data.identity)) {
       return errorHandle({
-        identity: identity,
+        identity,
         path: pathname,
-        platform: platform || "search",
+        platform: platform || "graph",
         code: 404,
         message: ErrorMessages.NOT_FOUND,
       });
     }
 
-    const result = await processJson(res);
-
+    const result = await processJson(rawJson);
     return respondJson(result);
   } catch (e: unknown) {
     return errorHandle({
-      identity: identity,
+      identity,
       path: pathname,
-      platform: platform,
+      platform,
       message: e instanceof Error ? e.message : ErrorMessages.NOT_FOUND,
       code: e instanceof Error ? Number(e.cause) || 500 : 500,
     });

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -8,7 +8,13 @@ import {
   ProfileRecord,
 } from "@/utils/types";
 import { errorHandle, getUserHeaders, respondJson } from "@/utils/utils";
-import { getQuery, QueryType } from "@/utils/query";
+import {
+  getQuery,
+  identityGraphErrorMessage,
+  identityGraphErrorStatus,
+  postIdentityGraphQuery,
+  QueryType,
+} from "@/utils/query";
 
 const processProfileAvatar = async (
   profile: ProfileRecord,
@@ -103,33 +109,40 @@ export async function GET(req: NextRequest) {
     });
   }
   try {
-    const rawJson = await fetch(process.env.GRAPHQL_SERVER || "", {
-      method: "POST",
-      headers: {
-        ...headers,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        query: getQuery(QueryType.GET_SEARCH_QUERY),
-        variables: { identity, platform },
-      }),
-    }).then((res) => res.json());
+    const { ok, status, body: rawJson } = await postIdentityGraphQuery(
+      headers,
+      getQuery(QueryType.GET_SEARCH_QUERY),
+      { identity, platform },
+    );
 
-    if (rawJson?.code || rawJson?.errors) {
+    const envelope = rawJson as {
+      code?: number;
+      errors?: unknown;
+      data?: { identity?: IdentityRecord };
+    } | null;
+
+    if (!ok || envelope?.code || envelope?.errors) {
       return errorHandle({
         identity,
         path: pathname,
         platform,
-        code: rawJson.code,
-        message:
-          rawJson.msg ||
-          (rawJson.errors
-            ? JSON.stringify(rawJson.errors)
-            : ErrorMessages.NOT_FOUND),
+        code: identityGraphErrorStatus(ok, status, envelope?.code),
+        message: identityGraphErrorMessage(envelope, ErrorMessages.NOT_FOUND),
       });
     }
 
-    if (isSingleWeb2Identity(rawJson.data.identity)) {
+    const graphIdentity = envelope?.data?.identity;
+    if (!graphIdentity) {
+      return errorHandle({
+        identity,
+        path: pathname,
+        platform,
+        code: 404,
+        message: ErrorMessages.NOT_FOUND,
+      });
+    }
+
+    if (isSingleWeb2Identity(graphIdentity)) {
       return errorHandle({
         identity,
         path: pathname,
@@ -139,7 +152,7 @@ export async function GET(req: NextRequest) {
       });
     }
 
-    const result = await processJson(rawJson);
+    const result = await processJson(envelope as IdentityGraphQueryResponse);
     return respondJson(result);
   } catch (e: unknown) {
     return errorHandle({

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -7,7 +7,7 @@ import {
   IdentityRecord,
   ProfileRecord,
 } from "@/utils/types";
-import { errorHandle, respondJson } from "@/utils/utils";
+import { errorHandle, getUserHeaders, respondJson } from "@/utils/utils";
 import { getQuery, QueryType } from "@/utils/query";
 
 const processProfileAvatar = async (
@@ -91,6 +91,7 @@ export async function GET(req: NextRequest) {
   const { searchParams, pathname } = req.nextUrl;
   const identity = searchParams.get("identity");
   const platform = searchParams.get("platform") as Platform;
+  const headers = getUserHeaders(req.headers);
 
   if (!identity || !platform) {
     return errorHandle({
@@ -105,7 +106,7 @@ export async function GET(req: NextRequest) {
     const rawJson = await fetch(process.env.GRAPHQL_SERVER || "", {
       method: "POST",
       headers: {
-        "x-api-key": process.env.WEB3BIO_API_KEY || "",
+        ...headers,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({

--- a/app/api/search/suggest/[name]/route.ts
+++ b/app/api/search/suggest/[name]/route.ts
@@ -1,9 +1,5 @@
 import { getQuery, QueryType } from "@/utils/query";
-import {
-  getUserHeaders,
-  IDENTITY_GRAPH_SERVER,
-  respondJson,
-} from "@/utils/utils";
+import { respondJson } from "@/utils/utils";
 import { NextRequest, NextResponse } from "next/server";
 import { Platform } from "web3bio-profile-kit/types";
 
@@ -20,12 +16,12 @@ export async function GET(
   if (!name || typeof name !== "string") {
     return NextResponse.json([]);
   }
-  const headers = getUserHeaders(req.headers);
-  const results = await fetch(IDENTITY_GRAPH_SERVER, {
+
+  const results = await fetch(process.env.GRAPHQL_SERVER || "", {
     method: "POST",
     headers: {
-      ...headers,
       "Content-Type": "application/json",
+      "x-api-key": process.env.WEB3BIO_API_KEY || "",
     },
     body: JSON.stringify({
       query: getQuery(QueryType.GET_SEARCH_SUGGEST),

--- a/app/api/search/suggest/[name]/route.ts
+++ b/app/api/search/suggest/[name]/route.ts
@@ -1,5 +1,5 @@
 import { getQuery, QueryType } from "@/utils/query";
-import { respondJson } from "@/utils/utils";
+import { getUserHeaders, respondJson } from "@/utils/utils";
 import { NextRequest, NextResponse } from "next/server";
 import { Platform } from "web3bio-profile-kit/types";
 
@@ -16,12 +16,13 @@ export async function GET(
   if (!name || typeof name !== "string") {
     return NextResponse.json([]);
   }
+  const headers = getUserHeaders(req.headers);
 
   const results = await fetch(process.env.GRAPHQL_SERVER || "", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "x-api-key": process.env.WEB3BIO_API_KEY || "",
+      ...headers,
     },
     body: JSON.stringify({
       query: getQuery(QueryType.GET_SEARCH_SUGGEST),

--- a/app/api/search/suggest/[name]/route.ts
+++ b/app/api/search/suggest/[name]/route.ts
@@ -1,56 +1,49 @@
-import { getQuery, QueryType } from "@/utils/query";
-import { getUserHeaders, respondJson } from "@/utils/utils";
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 import { Platform } from "web3bio-profile-kit/types";
+import { getQuery, postIdentityGraphQuery, QueryType } from "@/utils/query";
+import { getUserHeaders, normalizeText, respondJson } from "@/utils/utils";
 
 interface NameSuggest {
   name: string;
   platform: Platform;
 }
 
+function mapSuggestItem(x: NameSuggest): NameSuggest {
+  return x.platform === Platform.box
+    ? { platform: Platform.ens, name: x.name }
+    : x;
+}
+
 export async function GET(
   req: NextRequest,
-  props: { params: Promise<{ name: string }> },
-): Promise<NextResponse> {
-  const { name } = await props.params;
-  if (!name || typeof name !== "string") {
-    return NextResponse.json([]);
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const name = normalizeText((await params).name);
+  if (!name.trim()) {
+    return respondJson([]);
   }
+
   const headers = getUserHeaders(req.headers);
 
-  const results = await fetch(process.env.GRAPHQL_SERVER || "", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...headers,
-    },
-    body: JSON.stringify({
-      query: getQuery(QueryType.GET_SEARCH_SUGGEST),
-      variables: { name },
-    }),
-  })
-    .then((res) => res.json())
-    .then((result) => {
-      if (!result || result.errors) {
-        return [];
-      }
+  try {
+    const { ok, body } = await postIdentityGraphQuery(
+      headers,
+      getQuery(QueryType.GET_SEARCH_SUGGEST),
+      { name },
+    );
 
-      return (
-        result.data?.nameSuggest.map((x: NameSuggest) => {
-          if (x.platform === Platform.box) {
-            return {
-              platform: Platform.ens,
-              name: x.name,
-            };
-          } else {
-            return x;
-          }
-        }) || []
-      );
-    })
-    .catch((e) => {
-      return [];
-    });
+    const result = body as {
+      data?: { nameSuggest?: NameSuggest[] };
+      errors?: unknown;
+    } | null;
 
-  return respondJson(results);
+    if (!ok || !result || result.errors) {
+      return respondJson([]);
+    }
+
+    const list: NameSuggest[] = result.data?.nameSuggest ?? [];
+    return respondJson(list.map(mapSuggestItem));
+  } catch {
+    return respondJson([]);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "viem": "^2.39.3",
-    "web3bio-profile-kit": "^0.2.4"
+    "web3bio-profile-kit": "^0.2.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^2.39.3
         version: 2.39.3(typescript@5.8.3)(zod@3.22.3)
       web3bio-profile-kit:
-        specifier: ^0.2.4
-        version: 0.2.4(@tanstack/react-query@5.90.10(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^0.2.5
+        version: 0.2.5(@tanstack/react-query@5.90.10(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.1
@@ -4361,8 +4361,8 @@ packages:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
 
-  web3bio-profile-kit@0.2.4:
-    resolution: {integrity: sha512-j5usFJx46rnBXu3P2ExhVGokvQppWovgr4k07zewO70sQ7lr7P9s8XZopF46peAzuGHVj1VzscDO0tvZodj7aQ==}
+  web3bio-profile-kit@0.2.5:
+    resolution: {integrity: sha512-0kwTD1q9cHvGdjzCD9wy9chYSV8t0i9OCETqo9Q1bx3k8xApXS0QEDINl5Wj5DFinMIlvbfV3T0vRcHDgXaedA==}
     peerDependencies:
       '@tanstack/react-query': ^4.0.0 || ^5.0.0
       react: '>=16.8.0'
@@ -10115,7 +10115,7 @@ snapshots:
 
   web-streams-polyfill@4.0.0-beta.3: {}
 
-  web3bio-profile-kit@0.2.4(@tanstack/react-query@5.90.10(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  web3bio-profile-kit@0.2.5(@tanstack/react-query@5.90.10(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@tanstack/react-query': 5.90.10(react@19.2.0)
       react: 19.2.0

--- a/utils/query.ts
+++ b/utils/query.ts
@@ -482,7 +482,7 @@ export const GET_SEARCH_SUGGEST = `
 `;
 // Search Query
 const GET_SEARCH_QUERY = `
-  query GET_SEARCH_PROFILES($platform: Platform!, $identity: String!) {
+ query GET_GRAPH_QUERY($platform: Platform!, $identity: String!) {
     identity(platform: $platform, identity: $identity) {
       identity
       platform

--- a/utils/query.ts
+++ b/utils/query.ts
@@ -569,6 +569,68 @@ export function getQuery(type: QueryType): string {
   return query;
 }
 
+export interface IdentityGraphPostResult {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  body: unknown;
+}
+
+export async function postIdentityGraphQuery(
+  headers: AuthHeaders,
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<IdentityGraphPostResult> {
+  const response = await fetch(IDENTITY_GRAPH_SERVER, {
+    method: "POST",
+    headers: {
+      ...headers,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    statusText: response.statusText,
+    body,
+  };
+}
+
+/** Resolve HTTP status for Identity Graph error responses (body `code` wins when numeric). */
+export function identityGraphErrorStatus(
+  responseOk: boolean,
+  httpStatus: number,
+  bodyCode: unknown,
+): number {
+  if (typeof bodyCode === "number" && !Number.isNaN(bodyCode)) {
+    return bodyCode;
+  }
+  return responseOk ? 500 : httpStatus;
+}
+
+export function identityGraphErrorMessage(
+  body: unknown,
+  fallback: string,
+): string {
+  if (!body || typeof body !== "object") {
+    return fallback;
+  }
+  const b = body as { msg?: string; errors?: unknown };
+  return (
+    b.msg ||
+    (b.errors != null ? JSON.stringify(b.errors) : fallback)
+  );
+}
+
 export async function queryIdentityGraph(
   query: QueryType,
   handle: string,
@@ -579,29 +641,19 @@ export async function queryIdentityGraph(
     return { errors: `Unable to detect platform for handle: ${handle}` };
   }
   try {
-    const response = await fetch(IDENTITY_GRAPH_SERVER, {
-      method: "POST",
-      headers: {
-        ...headers,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        query: getQuery(query),
-        variables: {
-          identity: handle,
-          platform,
-        },
-      }),
+    const r = await postIdentityGraphQuery(headers, getQuery(query), {
+      identity: handle,
+      platform,
     });
 
-    if (!response.ok) {
+    if (!r.ok) {
       return {
-        errors: `HTTP ${response.status}: ${response.statusText}`,
-        code: response.status,
+        errors: `HTTP ${r.status}: ${r.statusText}`,
+        code: r.status,
       };
     }
 
-    return await response.json();
+    return r.body as any;
   } catch (error) {
     return {
       errors: error instanceof Error ? error.message : "Unknown error occurred",
@@ -616,23 +668,17 @@ export async function queryBatchUniversal(ids: string[], headers: AuthHeaders) {
   }
 
   try {
-    const response = await fetch(IDENTITY_GRAPH_SERVER, {
-      method: "POST",
-      headers: {
-        ...headers,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        query: getQuery(QueryType.GET_BATCH_UNIVERSAL),
-        variables: { ids: queryIds },
-      }),
-    });
+    const r = await postIdentityGraphQuery(
+      headers,
+      getQuery(QueryType.GET_BATCH_UNIVERSAL),
+      { ids: queryIds },
+    );
 
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    if (!r.ok) {
+      throw new Error(`HTTP ${r.status}: ${r.statusText}`);
     }
 
-    const json = await response.json();
+    const json = r.body as any;
     const identities = json?.data?.identitiesWithGraph;
 
     if (!Array.isArray(identities)) {
@@ -698,23 +744,17 @@ export async function queryIdentityGraphBatch(
   }
 
   try {
-    const response = await fetch(IDENTITY_GRAPH_SERVER, {
-      method: "POST",
-      headers: {
-        ...headers,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        query: getQuery(QueryType.GET_BATCH),
-        variables: { ids: queryIds },
-      }),
-    });
+    const r = await postIdentityGraphQuery(
+      headers,
+      getQuery(QueryType.GET_BATCH),
+      { ids: queryIds },
+    );
 
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    if (!r.ok) {
+      throw new Error(`HTTP ${r.status}: ${r.statusText}`);
     }
 
-    const json = await response.json();
+    const json = r.body as any;
 
     if (!json?.data?.identities) {
       return json || [];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes API response ordering/filtering and swaps GraphQL endpoint configuration to `process.env.GRAPHQL_SERVER`, which can affect production query behavior and error handling.
> 
> **Overview**
> **Search and availability endpoints now query GraphQL via `process.env.GRAPHQL_SERVER`** (instead of the prior constant) and tighten error handling, returning a 500 when GraphQL returns `errors` and preserving `code`/`msg` handling separately.
> 
> **Search response shaping was adjusted**: avatar processing is refactored into a single task list, identity-graph vertices/edges now filter out `clusters` nodes containing `/`, and the current identity is only injected into the vertex list when it wasn’t filtered. Profile resolution sorting now additionally groups results by matching `address` to the source address for `ethereum`/`solana` lookups.
> 
> Test descriptions were normalized (`response` → `respond`), one universal profile assertion was updated (`ethereum` → `lens`), the search query operation name was renamed, and `web3bio-profile-kit` was bumped to `^0.2.5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 861dfe3d0dceeb47f96779d03736954fa7c22c91. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->