### PR TITLE
Staging

### DIFF
--- a/__tests__/ens-widgets.test.ts
+++ b/__tests__/ens-widgets.test.ts
@@ -1,0 +1,34 @@
+import { serializeEnsWidgetsFromTexts } from "@/utils/ens-widgets";
+
+describe("serializeEnsWidgetsFromTexts", () => {
+  it("returns a native array (not a JSON string) on the wire", () => {
+    const texts = {
+      widgets: JSON.stringify([
+        { n: "GitHub", u: "https://github.com/foo" },
+        { n: "Links", u: ["https://a.com", "https://b.com"], w: "card" },
+      ]),
+      links: JSON.stringify([
+        { name: "GitHub", url: "https://github.com/merged" },
+      ]),
+    };
+
+    const widgets = serializeEnsWidgetsFromTexts(texts);
+    expect(Array.isArray(widgets)).toBe(true);
+
+    const wire = JSON.stringify({ widgets });
+    expect(wire).not.toMatch(/"widgets":"\[/);
+    expect(wire).toContain('"widgets":[{"name":"GitHub"');
+
+    const github = widgets?.find((w) => w.name === "GitHub");
+    expect(github?.url).toBe("https://github.com/merged");
+
+    const links = widgets?.find((w) => w.name === "Links");
+    expect(links?.url).toEqual(["https://a.com", "https://b.com"]);
+    expect(links?.widget).toBe("card");
+  });
+
+  it("returns null when texts are missing or empty", () => {
+    expect(serializeEnsWidgetsFromTexts(undefined)).toBeNull();
+    expect(serializeEnsWidgetsFromTexts({})).toBeNull();
+  });
+});

--- a/app/api/profile/basenames/[handle]/route.ts
+++ b/app/api/profile/basenames/[handle]/route.ts
@@ -39,7 +39,7 @@ export async function GET(
       message: ErrorMessages.INVALID_IDENTITY,
     });
   }
-
+  const isRefresh = req.nextUrl.searchParams.get("refresh") === "true";
   const headers = getUserHeaders(req.headers);
   return resolveIdentityHandle(
     handle,
@@ -47,5 +47,6 @@ export async function GET(
     headers,
     false,
     pathname,
+    isRefresh,
   );
 }

--- a/app/api/profile/ens/[handle]/route.ts
+++ b/app/api/profile/ens/[handle]/route.ts
@@ -11,7 +11,7 @@ export async function GET(
   const { handle: rawHandle } = await params;
   const { pathname } = req.nextUrl;
   const handle = rawHandle?.trim() ?? "";
-
+  const isRefresh = req.nextUrl.searchParams.get("refresh") === "true";
   if (!handle || (!REGEX.ENS.test(handle) && !isValidEthereumAddress(handle))) {
     return errorHandle({
       identity: handle,
@@ -23,5 +23,13 @@ export async function GET(
   }
 
   const headers = getUserHeaders(req.headers);
-  return resolveIdentityHandle(handle, Platform.ens, headers, false, pathname);
+
+  return resolveIdentityHandle(
+    handle,
+    Platform.ens,
+    headers,
+    false,
+    pathname,
+    isRefresh,
+  );
 }

--- a/app/api/profile/linea/[handle]/route.ts
+++ b/app/api/profile/linea/[handle]/route.ts
@@ -41,11 +41,13 @@ export async function GET(
   }
 
   const headers = getUserHeaders(req.headers);
+  const isRefresh = req.nextUrl.searchParams.get("refresh") === "true";
   return resolveIdentityHandle(
     handle,
     Platform.linea,
     headers,
     false,
     pathname,
+    isRefresh,
   );
 }

--- a/utils/base.ts
+++ b/utils/base.ts
@@ -200,17 +200,16 @@ export async function generateProfileStruct(
   }
 
   const socialData = await generateSocialLinks(data, edges, aliases);
-  const ensSerialized =
-    data.platform === Platform.ens
-      ? serializeEnsWidgetsFromTexts(data.texts)
-      : { widgets: null as string | null };
   const res = {
     ...nsObj,
     createdAt: data.createdAt ? formatTimestamp(data.createdAt) : null,
     email: data.texts?.email || null,
     location: resolveLocation(data.texts?.location),
     contenthash: socialData.contenthash || null,
-    widgets: ensSerialized.widgets,
+    widgets:
+      data.platform === Platform.ens
+        ? serializeEnsWidgetsFromTexts(data.texts)
+        : null,
     links: (socialData.links as SocialLinks) || {},
     social:
       data.social || data.uid

--- a/utils/base.ts
+++ b/utils/base.ts
@@ -37,120 +37,12 @@ import type {
   IdentityGraphQueryResponse,
   IdentityRecord,
 } from "@/utils/types";
+import { serializeEnsWidgetsFromTexts } from "@/utils/ens-widgets";
 
 interface ResolvedAliases {
   identity: string;
   aliases: IdentityString[];
 }
-
-interface EnsWidgetItem {
-  name: string | null;
-  url: string | null;
-  desc: string | null;
-  emoji: string | null;
-}
-
-const ENS_WIDGETS_TEXT_KEY = "web3.bio.widgets";
-const ENS_LINKS_TEXT_KEY = "links";
-
-const stringOrNull = (value: unknown): string | null => {
-  if (value == null) return null;
-  if (typeof value !== "string") return null;
-  const t = value.trim();
-  return t === "" ? null : t;
-};
-
-const parseEnsTextJsonArray = (raw: string | undefined): unknown[] => {
-  if (raw == null || raw === "") return [];
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-};
-
-const normalizeEnsWidgetsBioRow = (
-  row: Record<string, unknown>,
-): EnsWidgetItem | null => {
-  const name = stringOrNull(row.n ?? row.t ?? row.name);
-  if (!name) return null;
-  return {
-    name,
-    url: stringOrNull(row.u ?? row.url),
-    desc: stringOrNull(row.d ?? row.desc ?? row.description),
-    emoji: stringOrNull(row.e ?? row.emoji),
-  };
-};
-
-const normalizeEnsLinksRow = (row: Record<string, unknown>): EnsWidgetItem | null => {
-  const name = stringOrNull(row.name);
-  if (!name) return null;
-  return {
-    name,
-    url: stringOrNull(row.url),
-    desc: stringOrNull(row.desc ?? row.description),
-    emoji: stringOrNull(row.emoji),
-  };
-};
-
-const mergeEnsWidgetsItems = (
-  texts: Record<string, string> | undefined,
-): EnsWidgetItem[] | null => {
-  if (!texts) return null;
-
-  const widgetRows = parseEnsTextJsonArray(texts[ENS_WIDGETS_TEXT_KEY]) as Record<
-    string,
-    unknown
-  >[];
-  const linkRows = parseEnsTextJsonArray(texts[ENS_LINKS_TEXT_KEY]) as Record<
-    string,
-    unknown
-  >[];
-
-  const byName = new Map<string, EnsWidgetItem>();
-
-  for (const raw of widgetRows) {
-    if (!raw || typeof raw !== "object") continue;
-    const item = normalizeEnsWidgetsBioRow(raw);
-    if (!item || item.name == null) continue;
-    byName.set(item.name, item);
-  }
-
-  for (const raw of linkRows) {
-    if (!raw || typeof raw !== "object") continue;
-    const linkItem = normalizeEnsLinksRow(raw);
-    if (!linkItem || linkItem.name == null) continue;
-
-    const prev = byName.get(linkItem.name);
-    if (!prev) {
-      byName.set(linkItem.name, {
-        name: linkItem.name,
-        url: linkItem.url,
-        desc: linkItem.desc,
-        emoji: linkItem.emoji,
-      });
-      continue;
-    }
-
-    byName.set(linkItem.name, {
-      name: prev.name,
-      url: linkItem.url ?? prev.url,
-      desc: prev.desc ?? linkItem.desc,
-      emoji: linkItem.emoji ?? prev.emoji,
-    });
-  }
-
-  if (byName.size === 0) return null;
-  return [...byName.values()];
-};
-
-export const serializeEnsWidgetsFromTexts = (
-  texts: Record<string, string> | undefined,
-): string | null => {
-  const items = mergeEnsWidgetsItems(texts);
-  return items ? JSON.stringify(items) : null;
-};
 
 const UD_ACCOUNTS_LIST = [
   Platform.twitter,
@@ -291,16 +183,17 @@ export async function generateProfileStruct(
   }
 
   const socialData = await generateSocialLinks(data, edges, aliases);
+  const ensSerialized =
+    data.platform === Platform.ens
+      ? serializeEnsWidgetsFromTexts(data.texts)
+      : { widgets: null as string | null };
   const res = {
     ...nsObj,
     createdAt: data.createdAt ? formatTimestamp(data.createdAt) : null,
     email: data.texts?.email || null,
     location: resolveLocation(data.texts?.location),
     contenthash: socialData.contenthash || null,
-    widgets:
-      data.platform === Platform.ens
-        ? serializeEnsWidgetsFromTexts(data.texts)
-        : null,
+    widgets: ensSerialized.widgets,
     links: (socialData.links as SocialLinks) || {},
     social:
       data.social || data.uid

--- a/utils/base.ts
+++ b/utils/base.ts
@@ -43,6 +43,115 @@ interface ResolvedAliases {
   aliases: IdentityString[];
 }
 
+interface EnsWidgetItem {
+  name: string | null;
+  url: string | null;
+  desc: string | null;
+  emoji: string | null;
+}
+
+const ENS_WIDGETS_TEXT_KEY = "web3.bio.widgets";
+const ENS_LINKS_TEXT_KEY = "links";
+
+const stringOrNull = (value: unknown): string | null => {
+  if (value == null) return null;
+  if (typeof value !== "string") return null;
+  const t = value.trim();
+  return t === "" ? null : t;
+};
+
+const parseEnsTextJsonArray = (raw: string | undefined): unknown[] => {
+  if (raw == null || raw === "") return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+const normalizeEnsWidgetsBioRow = (
+  row: Record<string, unknown>,
+): EnsWidgetItem | null => {
+  const name = stringOrNull(row.n ?? row.t ?? row.name);
+  if (!name) return null;
+  return {
+    name,
+    url: stringOrNull(row.u ?? row.url),
+    desc: stringOrNull(row.d ?? row.desc ?? row.description),
+    emoji: stringOrNull(row.e ?? row.emoji),
+  };
+};
+
+const normalizeEnsLinksRow = (row: Record<string, unknown>): EnsWidgetItem | null => {
+  const name = stringOrNull(row.name);
+  if (!name) return null;
+  return {
+    name,
+    url: stringOrNull(row.url),
+    desc: stringOrNull(row.desc ?? row.description),
+    emoji: stringOrNull(row.emoji),
+  };
+};
+
+const mergeEnsWidgetsItems = (
+  texts: Record<string, string> | undefined,
+): EnsWidgetItem[] | null => {
+  if (!texts) return null;
+
+  const widgetRows = parseEnsTextJsonArray(texts[ENS_WIDGETS_TEXT_KEY]) as Record<
+    string,
+    unknown
+  >[];
+  const linkRows = parseEnsTextJsonArray(texts[ENS_LINKS_TEXT_KEY]) as Record<
+    string,
+    unknown
+  >[];
+
+  const byName = new Map<string, EnsWidgetItem>();
+
+  for (const raw of widgetRows) {
+    if (!raw || typeof raw !== "object") continue;
+    const item = normalizeEnsWidgetsBioRow(raw);
+    if (!item || item.name == null) continue;
+    byName.set(item.name, item);
+  }
+
+  for (const raw of linkRows) {
+    if (!raw || typeof raw !== "object") continue;
+    const linkItem = normalizeEnsLinksRow(raw);
+    if (!linkItem || linkItem.name == null) continue;
+
+    const prev = byName.get(linkItem.name);
+    if (!prev) {
+      byName.set(linkItem.name, {
+        name: linkItem.name,
+        url: linkItem.url,
+        desc: linkItem.desc,
+        emoji: linkItem.emoji,
+      });
+      continue;
+    }
+
+    byName.set(linkItem.name, {
+      name: prev.name,
+      url: linkItem.url ?? prev.url,
+      desc: prev.desc ?? linkItem.desc,
+      emoji: linkItem.emoji ?? prev.emoji,
+    });
+  }
+
+  if (byName.size === 0) return null;
+  return [...byName.values()];
+};
+
+export const serializeEnsWidgetsFromTexts = (
+  texts: Record<string, string> | undefined,
+): string | null => {
+  const items = mergeEnsWidgetsItems(texts);
+  return items ? JSON.stringify(items) : null;
+};
+
 const UD_ACCOUNTS_LIST = [
   Platform.twitter,
   Platform.discord,
@@ -190,7 +299,7 @@ export async function generateProfileStruct(
     contenthash: socialData.contenthash || null,
     widgets:
       data.platform === Platform.ens
-        ? data.texts?.["web3.bio.widgets"] || null
+        ? serializeEnsWidgetsFromTexts(data.texts)
         : null,
     links: (socialData.links as SocialLinks) || {},
     social:

--- a/utils/base.ts
+++ b/utils/base.ts
@@ -88,9 +88,14 @@ export const resolveIdentityResponse = async (
   platform: Platform,
   headers: AuthHeaders,
   ns: boolean,
+  refresh: boolean,
 ) => {
   const res = await queryIdentityGraph(
-    ns ? QueryType.GET_PROFILES_NS : QueryType.GET_PROFILES,
+    refresh
+      ? QueryType.REFRESH_DOMAIN
+      : ns
+        ? QueryType.GET_PROFILES_NS
+        : QueryType.GET_PROFILES,
     handle,
     platform,
     headers,
@@ -105,7 +110,16 @@ export const resolveIdentityResponse = async (
     };
   }
 
-  const profile = res?.data?.identity?.profile;
+  const dr = refresh ? (res as any)?.data?.domainRefresh : null;
+  const identity = refresh
+    ? dr && {
+        profile: dr.profile as ProfileRecord,
+        registeredAt: dr.registeredAt,
+        identityGraph: undefined,
+      }
+    : (res as any)?.data?.identity;
+
+  const profile = identity?.profile;
 
   if (!profile) {
     if ([Platform.sns, Platform.ens].includes(platform)) {
@@ -140,13 +154,16 @@ export const resolveIdentityResponse = async (
     throw new Error(ErrorMessages.NOT_FOUND, { cause: 404 });
   }
 
+  const registeredAt = identity!.registeredAt;
+  const edges = identity!.identityGraph?.edges;
+
   return generateProfileStruct(
     {
       ...profile,
-      createdAt: res.data.identity?.registeredAt,
+      createdAt: registeredAt,
     },
     ns,
-    res.data.identity?.identityGraph?.edges,
+    edges,
   );
 };
 
@@ -219,6 +236,7 @@ export const resolveIdentityHandle = async (
   headers: AuthHeaders,
   ns: boolean = false,
   pathname: string,
+  refresh: boolean = false,
 ) => {
   try {
     const response = await resolveIdentityResponse(
@@ -226,6 +244,7 @@ export const resolveIdentityHandle = async (
       platform,
       headers,
       ns,
+      refresh
     );
     if ("code" in response) {
       return errorHandle({

--- a/utils/ens-widgets.ts
+++ b/utils/ens-widgets.ts
@@ -1,0 +1,107 @@
+type Row = Record<string, unknown>;
+
+const str = (v: unknown): string | null =>
+  typeof v === "string" && v.trim() ? v.trim() : null;
+
+const jsonArr = (raw?: string): unknown[] => {
+  if (!raw) return [];
+  try {
+    const x = JSON.parse(raw);
+    return Array.isArray(x) ? x : [];
+  } catch {
+    return [];
+  }
+};
+
+type Item = {
+  name: string | null;
+  url: string | null;
+  desc: string | null;
+  emoji: string | null;
+  widget: string | null;
+};
+
+const urlField = (v: unknown): string | null => {
+  if (typeof v === "string") return str(v);
+  if (!Array.isArray(v)) return null;
+  const urls: string[] = [];
+  for (const x of v) {
+    if (typeof x !== "string") continue;
+    const u = str(x);
+    if (u) urls.push(u);
+  }
+  return urls.length ? JSON.stringify(urls) : null;
+};
+
+const linkRow = (o: Row): Item | null => {
+  const name = str(o.name);
+  if (!name) return null;
+  return {
+    name,
+    url: str(o.url),
+    desc: str(o.desc ?? o.description),
+    emoji: str(o.emoji),
+    widget: null,
+  };
+};
+
+const bioRow = (o: Row): Item | null => {
+  const widget = str(o.w);
+  const name = str(o.n ?? o.t ?? o.name);
+  const url = urlField(o.u ?? o.url);
+  const desc = str(o.d ?? o.desc ?? o.description);
+  const emoji = str(o.e ?? o.emoji);
+  if (!name && !url && !widget && !desc && !emoji) return null;
+  return { name, url, desc, emoji, widget };
+};
+
+export const serializeEnsWidgetsFromTexts = (
+  texts: Record<string, string> | undefined,
+): { widgets: string | null } => {
+  if (!texts) return { widgets: null };
+
+  const items: Item[] = [];
+  const nameIdx = new Map<string, number>();
+
+  for (const x of jsonArr(texts["web3.bio.widgets"])) {
+    if (!x || typeof x !== "object") continue;
+    const row = bioRow(x as Row);
+    if (!row) continue;
+    if (row.name) {
+      const i = nameIdx.get(row.name);
+      if (i !== undefined) items[i] = row;
+      else {
+        nameIdx.set(row.name, items.length);
+        items.push(row);
+      }
+    } else {
+      items.push(row);
+    }
+  }
+
+  for (const x of jsonArr(texts.links)) {
+    if (!x || typeof x !== "object") continue;
+    const L = linkRow(x as Row);
+    if (!L) continue;
+    const linkName = L.name;
+    if (!linkName) continue;
+    const i = nameIdx.get(linkName);
+    if (i !== undefined) {
+      const P = items[i];
+      items[i] = {
+        name: P.name,
+        url: L.url ?? P.url,
+        desc: P.desc ?? L.desc,
+        emoji: L.emoji ?? P.emoji,
+        widget: P.widget,
+      };
+    } else {
+      nameIdx.set(linkName, items.length);
+      items.push(L);
+    }
+  }
+
+  return {
+    widgets: items.length ? JSON.stringify(items) : null,
+  };
+};

--- a/utils/ens-widgets.ts
+++ b/utils/ens-widgets.ts
@@ -73,7 +73,7 @@ export const serializeEnsWidgetsFromTexts = (
   const items: Item[] = [];
   const nameIdx = new Map<string, number>();
 
-  for (const x of jsonArr(texts["web3.bio.widgets"])) {
+  for (const x of jsonArr(texts["widgets"])) {
     if (!x || typeof x !== "object") continue;
     const row = bioRow(x as Row);
     if (!row) continue;

--- a/utils/ens-widgets.ts
+++ b/utils/ens-widgets.ts
@@ -55,6 +55,16 @@ const bioRow = (o: Row): Item | null => {
   return { name, url, desc, emoji, widget };
 };
 
+const stripNulls = (row: Item): Record<string, unknown> => {
+  const o: Record<string, unknown> = {};
+  if (row.name != null) o.name = row.name;
+  if (row.url != null) o.url = row.url;
+  if (row.desc != null) o.desc = row.desc;
+  if (row.emoji != null) o.emoji = row.emoji;
+  if (row.widget != null) o.widget = row.widget;
+  return o;
+};
+
 export const serializeEnsWidgetsFromTexts = (
   texts: Record<string, string> | undefined,
 ): { widgets: string | null } => {
@@ -102,6 +112,6 @@ export const serializeEnsWidgetsFromTexts = (
   }
 
   return {
-    widgets: items.length ? JSON.stringify(items) : null,
+    widgets: items.length ? JSON.stringify(items.map(stripNulls)) : null,
   };
 };

--- a/utils/ens-widgets.ts
+++ b/utils/ens-widgets.ts
@@ -1,5 +1,13 @@
 type Row = Record<string, unknown>;
 
+export type EnsWidgetItem = {
+  name?: string;
+  url?: string | string[];
+  desc?: string;
+  emoji?: string;
+  widget?: string;
+};
+
 const str = (v: unknown): string | null =>
   typeof v === "string" && v.trim() ? v.trim() : null;
 
@@ -13,105 +21,93 @@ const jsonArr = (raw?: string): unknown[] => {
   }
 };
 
-type Item = {
+const urlField = (v: unknown): string | string[] | null => {
+  if (typeof v === "string") return str(v);
+  if (!Array.isArray(v)) return null;
+  const urls = v
+    .filter((x): x is string => typeof x === "string")
+    .map((x) => str(x))
+    .filter((u): u is string => u != null);
+  if (!urls.length) return null;
+  return urls.length === 1 ? urls[0] : urls;
+};
+
+const compact = (row: {
   name: string | null;
-  url: string | null;
+  url: string | string[] | null;
   desc: string | null;
   emoji: string | null;
   widget: string | null;
+}): EnsWidgetItem | null => {
+  const item: EnsWidgetItem = {};
+  if (row.name) item.name = row.name;
+  if (row.url != null) item.url = row.url;
+  if (row.desc) item.desc = row.desc;
+  if (row.emoji) item.emoji = row.emoji;
+  if (row.widget) item.widget = row.widget;
+  return Object.keys(item).length ? item : null;
 };
 
-const urlField = (v: unknown): string | null => {
-  if (typeof v === "string") return str(v);
-  if (!Array.isArray(v)) return null;
-  const urls: string[] = [];
-  for (const x of v) {
-    if (typeof x !== "string") continue;
-    const u = str(x);
-    if (u) urls.push(u);
-  }
-  return urls.length ? JSON.stringify(urls) : null;
-};
-
-const linkRow = (o: Row): Item | null => {
-  const name = str(o.name);
-  if (!name) return null;
-  return {
-    name,
-    url: str(o.url),
-    desc: str(o.desc ?? o.description),
-    emoji: str(o.emoji),
-    widget: null,
-  };
-};
-
-const bioRow = (o: Row): Item | null => {
-  const widget = str(o.w);
-  const name = str(o.n ?? o.t ?? o.name);
-  const url = urlField(o.u ?? o.url);
-  const desc = str(o.d ?? o.desc ?? o.description);
-  const emoji = str(o.e ?? o.emoji);
+const parseRow = (o: Row, shortKeys: boolean): EnsWidgetItem | null => {
+  const name = shortKeys ? str(o.n ?? o.t ?? o.name) : str(o.name);
+  const url = urlField(shortKeys ? (o.u ?? o.url) : o.url);
+  const desc = str(
+    shortKeys ? (o.d ?? o.desc ?? o.description) : (o.desc ?? o.description),
+  );
+  const emoji = str(shortKeys ? (o.e ?? o.emoji) : o.emoji);
+  const widget = shortKeys ? str(o.w) : null;
   if (!name && !url && !widget && !desc && !emoji) return null;
-  return { name, url, desc, emoji, widget };
+  if (!shortKeys && !name) return null;
+  return compact({ name, url, desc, emoji, widget });
 };
 
-const stripNulls = (row: Item): Record<string, unknown> => {
-  const o: Record<string, unknown> = {};
-  if (row.name != null) o.name = row.name;
-  if (row.url != null) o.url = row.url;
-  if (row.desc != null) o.desc = row.desc;
-  if (row.emoji != null) o.emoji = row.emoji;
-  if (row.widget != null) o.widget = row.widget;
-  return o;
+const mergeItems = (prev: EnsWidgetItem, next: EnsWidgetItem): EnsWidgetItem => ({
+  name: prev.name ?? next.name,
+  url: next.url ?? prev.url,
+  desc: next.desc ?? prev.desc,
+  emoji: next.emoji ?? prev.emoji,
+  widget: prev.widget ?? next.widget,
+});
+
+const upsertByName = (
+  items: EnsWidgetItem[],
+  nameIdx: Map<string, number>,
+  row: EnsWidgetItem,
+  merge = false,
+) => {
+  const name = row.name;
+  if (!name) {
+    items.push(row);
+    return;
+  }
+  const i = nameIdx.get(name);
+  if (i !== undefined) {
+    items[i] = merge ? mergeItems(items[i], row) : row;
+  } else {
+    nameIdx.set(name, items.length);
+    items.push(row);
+  }
 };
 
 export const serializeEnsWidgetsFromTexts = (
   texts: Record<string, string> | undefined,
-): { widgets: string | null } => {
-  if (!texts) return { widgets: null };
+): EnsWidgetItem[] | null => {
+  if (!texts) return null;
 
-  const items: Item[] = [];
+  const items: EnsWidgetItem[] = [];
   const nameIdx = new Map<string, number>();
 
   for (const x of jsonArr(texts["widgets"])) {
     if (!x || typeof x !== "object") continue;
-    const row = bioRow(x as Row);
-    if (!row) continue;
-    if (row.name) {
-      const i = nameIdx.get(row.name);
-      if (i !== undefined) items[i] = row;
-      else {
-        nameIdx.set(row.name, items.length);
-        items.push(row);
-      }
-    } else {
-      items.push(row);
-    }
+    const row = parseRow(x as Row, true);
+    if (row) upsertByName(items, nameIdx, row);
   }
 
   for (const x of jsonArr(texts.links)) {
     if (!x || typeof x !== "object") continue;
-    const L = linkRow(x as Row);
-    if (!L) continue;
-    const linkName = L.name;
-    if (!linkName) continue;
-    const i = nameIdx.get(linkName);
-    if (i !== undefined) {
-      const P = items[i];
-      items[i] = {
-        name: P.name,
-        url: L.url ?? P.url,
-        desc: P.desc ?? L.desc,
-        emoji: L.emoji ?? P.emoji,
-        widget: P.widget,
-      };
-    } else {
-      nameIdx.set(linkName, items.length);
-      items.push(L);
-    }
+    const row = parseRow(x as Row, false);
+    if (row) upsertByName(items, nameIdx, row, true);
   }
 
-  return {
-    widgets: items.length ? JSON.stringify(items.map(stripNulls)) : null,
-  };
+  return items.length ? items : null;
 };

--- a/utils/query.ts
+++ b/utils/query.ts
@@ -535,12 +535,6 @@ const REFRESH_DOMAIN = `
       expiredAt
       updatedAt
       registeredAt
-      credentials {
-        type
-        value
-        dataSource
-        link
-      }
       profile {
         uid
         identity

--- a/utils/query.ts
+++ b/utils/query.ts
@@ -22,6 +22,7 @@ export enum QueryType {
   GET_SEARCH_SUGGEST = "GET_SEARCH_SUGGEST",
   GET_SEARCH_QUERY = "GET_SEARCH_QUERY",
   GET_WALLET_QUERY = "GET_WALLET_QUERY",
+  REFRESH_DOMAIN = "REFRESH_DOMAIN",
 }
 
 const GET_WALLET_QUERY = `
@@ -508,6 +509,64 @@ const GET_SEARCH_QUERY = `
   }
 `;
 
+const REFRESH_DOMAIN = `
+  query REFRESH_DOMAIN($platform: Platform!, $identity: String!) {
+    domainRefresh(platform: $platform, identity: $identity) {
+      id
+      aliases
+      identity
+      platform
+      network
+      primaryName
+      isPrimary
+      resolver
+      resolvedAddress {
+        network
+        address
+      }
+      ownerAddress {
+        network
+        address
+      }
+      managerAddress {
+        network
+        address
+      }
+      expiredAt
+      updatedAt
+      registeredAt
+      credentials {
+        type
+        value
+        dataSource
+        link
+      }
+      profile {
+        uid
+        identity
+        platform
+        network
+        address
+        displayName
+        avatar
+        description
+        contenthash
+        texts
+        addresses {
+          network
+          address
+        }
+        social {
+          uid
+          follower
+          following
+        }
+      }
+      status
+    }
+  }
+`;
+
 const QUERY_MAP = new Map<QueryType, string>([
   [QueryType.GET_CREDENTIALS_QUERY, GET_CREDENTIALS_QUERY],
   [QueryType.GET_PROFILES_NS, GET_PROFILES_NS],
@@ -520,6 +579,7 @@ const QUERY_MAP = new Map<QueryType, string>([
   [QueryType.GET_SEARCH_SUGGEST, GET_SEARCH_SUGGEST],
   [QueryType.GET_SEARCH_QUERY, GET_SEARCH_QUERY],
   [QueryType.GET_WALLET_QUERY, GET_WALLET_QUERY],
+  [QueryType.REFRESH_DOMAIN, REFRESH_DOMAIN],
 ]);
 
 export function getQuery(type: QueryType): string {
@@ -586,10 +646,7 @@ export function identityGraphErrorMessage(
     return fallback;
   }
   const b = body as { msg?: string; errors?: unknown };
-  return (
-    b.msg ||
-    (b.errors != null ? JSON.stringify(b.errors) : fallback)
-  );
+  return b.msg || (b.errors != null ? JSON.stringify(b.errors) : fallback);
 }
 
 export async function queryIdentityGraph(
@@ -775,7 +832,10 @@ export async function queryIdentityGraphBatch(
           return directMatch;
         }
         const [platform, identity] = queryId.split(",");
-        return normalizedResultMap.get(`${platform},${normalizeText(identity)}`) || null;
+        return (
+          normalizedResultMap.get(`${platform},${normalizeText(identity)}`) ||
+          null
+        );
       })
       .filter(Boolean);
   } catch (error) {


### PR DESCRIPTION
Adds a `?refresh=true` capability to the ENS / basenames / linea profile routes that triggers a new `REFRESH_DOMAIN` GraphQL query against the identity graph, and replaces the raw `texts["web3.bio.widgets"]` string with a structured ENS widgets array built from `texts.widgets` and `texts.links`.